### PR TITLE
feat: Add Jekyll static site for GitHub Pages

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,59 @@
+# Build and deploy Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle install
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,22 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "just-the-docs", "~> 0.8"
+
+group :jekyll_plugins do
+  gem "jekyll-remote-theme"
+  gem "jekyll-seo-tag"
+  gem "jekyll-include-cache"
+end
+
+# Windows and JRuby does not include zoneinfo files
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,85 @@
+# Jekyll configuration for Midnight Improvement Proposals
+
+title: Midnight Improvement Proposals
+description: >-
+  A collection of Midnight Improvement Proposals (MIPs) - the primary mechanism
+  for proposing new features and documenting design decisions for Midnight.
+baseurl: "/midnight-improvement-proposals"
+url: "https://midnightntwrk.github.io"
+
+# Theme
+remote_theme: just-the-docs/just-the-docs@v0.8.2
+color_scheme: dark
+
+# Logo
+logo: "/assets/images/midnight-logo.png"
+
+# Search
+search_enabled: true
+search:
+  heading_level: 2
+  previews: 3
+  preview_words_before: 5
+  preview_words_after: 10
+  tokenizer_separator: /[\s/]+/
+  rel_url: true
+  button: false
+
+# Aux links (top right)
+aux_links:
+  "GitHub":
+    - "https://github.com/midnightntwrk/midnight-improvement-proposals"
+aux_links_new_tab: true
+
+# Navigation
+nav_enabled: true
+nav_sort: case_sensitive
+
+# Collections
+collections:
+  mips:
+    output: true
+    permalink: /:collection/:name
+
+# Defaults
+defaults:
+  - scope:
+      path: "mips"
+    values:
+      layout: default
+      nav_order: 2
+  - scope:
+      path: ""
+    values:
+      layout: default
+
+# Build settings
+markdown: kramdown
+highlighter: rouge
+
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+
+# Exclude from processing
+exclude:
+  - .git
+  - .github
+  - node_modules
+  - vendor
+  - Gemfile
+  - Gemfile.lock
+  - "*.gemspec"
+  - LICENSE
+  - SECURITY.md
+  - CODEOWNERS
+
+# Include
+include:
+  - _pages
+
+# Plugins
+plugins:
+  - jekyll-remote-theme
+  - jekyll-seo-tag
+  - jekyll-include-cache

--- a/assets/images/.gitkeep
+++ b/assets/images/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for logo and other images

--- a/index.md
+++ b/index.md
@@ -1,0 +1,76 @@
+---
+layout: home
+title: Home
+nav_order: 1
+description: "Midnight Improvement Proposals (MIPs) - The primary mechanism for proposing new features and documenting design decisions for the Midnight blockchain."
+permalink: /
+---
+
+# Midnight Improvement Proposals
+{: .fs-9 }
+
+The primary mechanism for proposing new features and documenting design decisions for the Midnight blockchain.
+{: .fs-6 .fw-300 }
+
+[View MIPs](/midnight-improvement-proposals/mips/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Submit a MIP](https://github.com/midnightntwrk/midnight-improvement-proposals/pulls){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+## What is a MIP?
+
+A **Midnight Improvement Proposal (MIP)** is a formalized design document for the Midnight community. It provides information or describes a change to the Midnight ecosystem, processes, or environment in sufficient technical detail.
+
+### Goals
+
+| Goal | Description |
+|:-----|:------------|
+| **Transparency** | All proposed changes are publicly visible and accessible |
+| **Community Participation** | Encourage community involvement in design and decision-making |
+| **Technical Soundness** | Ensure all changes are technically sound and well-specified |
+| **Documentation** | Maintain comprehensive records of all changes |
+| **Decentralization** | Support long-term decentralization of development |
+
+## MIP Categories
+
+- **Core** - Changes to the core protocol, consensus, or fundamental aspects
+- **Standards** - Application development standards and conventions
+- **Networking** - Network communication and peer discovery improvements
+- **Governance** - Proposals related to blockchain governance
+- **Informational** - General information and guidelines
+
+## MIP Statuses
+
+| Status | Description |
+|:-------|:------------|
+| **Draft** | Initial proposal under discussion |
+| **Review** | Being formally reviewed by MIP Editors |
+| **Accepted** | Approved and awaiting implementation |
+| **Final** | Fully implemented and deployed |
+| **Rejected** | Not accepted by the community |
+| **Withdrawn** | Removed by the author |
+
+## Quick Start
+
+### Reading MIPs
+
+Browse the [MIP list](/midnight-improvement-proposals/mips/) to see all proposals.
+
+### Submitting a MIP
+
+1. Fork the [repository](https://github.com/midnightntwrk/midnight-improvement-proposals)
+2. Create your MIP using the [template](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-template.md)
+3. Submit a Pull Request
+4. Engage in the review process
+
+---
+
+## Community
+
+- [GitHub Discussions](https://github.com/midnightntwrk/midnight-improvement-proposals/discussions)
+- [Contributing Guide](/midnight-improvement-proposals/CONTRIBUTING)
+- [Code of Conduct](/midnight-improvement-proposals/CODE_OF_CONDUCT)
+
+---
+
+<small>Inspired by [Cardano CIPs](https://cips.cardano.org/) and [Ethereum EIPs](https://eips.ethereum.org/)</small>

--- a/mips/index.md
+++ b/mips/index.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: All MIPs
+nav_order: 2
+has_children: true
+---
+
+# Midnight Improvement Proposals
+
+Browse all MIPs below. Each proposal goes through a formal review process before implementation.
+
+## MIP List
+
+| MIP | Title | Category | Status |
+|:----|:------|:---------|:-------|
+{% for mip in site.mips %}{% if mip.title != "All MIPs" %}| [{{ mip.mip_number | default: "TBD" }}]({{ mip.url | relative_url }}) | {{ mip.title }} | {{ mip.category | default: "Core" }} | {{ mip.status | default: "Draft" }} |
+{% endif %}{% endfor %}
+
+---
+
+## Submit a New MIP
+
+Ready to propose an improvement? Follow these steps:
+
+1. **Review existing MIPs** to avoid duplicates
+2. **Use the template** from [mip-template.md](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-template.md)
+3. **Submit a PR** to the repository
+4. **Engage** with the community during review
+
+[Submit a MIP](https://github.com/midnightntwrk/midnight-improvement-proposals/pulls){: .btn .btn-primary }


### PR DESCRIPTION
## Summary
Addresses #28 - Structure the MIP repository as a static site

This PR implements a Jekyll-based static site that can be deployed to GitHub Pages, similar to how [Cardano CIPs](https://cips.cardano.org/) works.

## Changes

### Jekyll Configuration (`_config.yml`)
- **Theme**: Just-the-Docs (dark color scheme)
- **Features**: Full-text search, SEO optimization
- **Collections**: Auto-discovery of MIP files

### Homepage (`index.md`)
- Overview of the MIP process
- Goals and categories explained
- Quick start guide for readers and contributors
- Links to community resources

### MIP Index (`mips/index.md`)
- Auto-generated table of all MIPs
- Dynamic status tracking
- Link to submission process

### GitHub Actions Workflow
- Auto-build on push to main
- Deploy to GitHub Pages
- Uses Ruby 3.2 for compatibility

### Dependencies (`Gemfile`)
- Jekyll 4.3
- just-the-docs theme
- Required plugins

## Deployment

After merge, enable GitHub Pages:
1. Go to Settings → Pages
2. Source: "GitHub Actions"
3. The workflow will auto-deploy

The site will be available at:
`https://midnightntwrk.github.io/midnight-improvement-proposals/`

## Preview

Features included:
- 🌙 Dark theme (matches Midnight branding)
- 🔍 Full-text search
- 📱 Mobile responsive
- 📊 Auto-generated MIP tables
- 🔗 SEO optimized

Bounty claim for Issue #28