### PR TITLE
feat: Structure repository as a static site (Jekyll)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,13 @@
+title: Midnight Improvement Proposals
+description: Midnight Improvement Proposals (MIPs) describe standards for the Midnight platform, including core protocol specifications, client APIs, and contract standards.
+theme: jekyll-theme-minimal
+baseurl: "/midnight-improvement-proposals" # Important for GH Pages project sites
+url: "https://midnightntwrk.github.io" # Replace with actual if known, or leave blank
+
+plugins:
+  - jekyll-seo-tag
+
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - node_modules

--- a/index.md
+++ b/index.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Home
+---
+
+# Midnight Improvement Proposals
+
+A Midnight Improvement Proposal (MIP) is a formalised design document for the Midnight community and the name of the process by which such documents are produced and listed. A MIP provides information or describes a change to the Midnight ecosystem, processes, or environment concisely and in sufficient technical detail.
+
+## MIP Status
+
+| MIP | Title | Status | Category |
+| :-: | :--- | :----: | :------- |
+{% assign mips = site.pages | sort: "MIP" %}
+{% for mip in mips %}
+  {% if mip.path contains 'mips/' and mip.MIP %}
+| [{{ mip.MIP }}]({{ mip.url | relative_url }}) | [{{ mip.Title }}]({{ mip.url | relative_url }}) | {{ mip.Status }} | {{ mip.Category }} |
+  {% endif %}
+{% endfor %}
+
+## Contributing
+
+Please review [MIP-1]({{ '/mips/mip-0001-Midnight-Improvement-Proposal-Process.html' | relative_url }}) for the full process.


### PR DESCRIPTION
Implements a basic Jekyll structure compatible with GitHub Pages. Adds _config.yml, Gemfile, and an index.md that dynamically lists MIPs. Resolves #28.