### PR TITLE
[MIP-0002] Correct order of fields in ShieldedReceive

### DIFF
--- a/mips/mip-0002-public-contract-log-emission.md
+++ b/mips/mip-0002-public-contract-log-emission.md
@@ -433,8 +433,8 @@ struct ShieldedSpend {
 
 struct ShieldedReceive {
     commitment: Bytes<32>,        // hint: indexed
-    contractAddress: Maybe<ContractAddress>,
-    ciphertext: Maybe<Bytes<512>> // hint: indexed
+    ciphertext: Maybe<Bytes<512>>,// hint: indexed
+    contractAddress: Maybe<ContractAddress>
 }
 
 struct ShieldedMint {


### PR DESCRIPTION
Due to the parallel work on the MIP and CoIP a desynchronization between the event types happened. This PR aims to align them.