### PR TITLE
[MIP-003] Add references to base specifications

### DIFF
--- a/mips/mip-0003-ecdsa-support.md
+++ b/mips/mip-0003-ecdsa-support.md
@@ -71,7 +71,7 @@ with 32-byte components, and 32-byte signing keys.
 ### Key management
 
 A new role value (`4`) is introduced in the key derivation hierarchy (see
-[key management specification](https://github.com/midnightntwrk/midnight-architecture/blob/main/components/WalletEngine/Specification.md#key-management)).
+[key management specification](https://github.com/midnightntwrk/midnight-architecture/blob/dc972159711251a1a7c073b3e0aa9982058b7131/components/WalletEngine/Specification.md#key-management)).
 This allows a single wallet to derive both Schnorr and ECDSA keys under the same account while
 keeping key material for the two schemes strictly separated:
 
@@ -95,7 +95,7 @@ is the compressed SEC1 encoding of a secp256k1 point.
 
 The user-facing address format for unshielded tokens is unchanged: Bech32m encoding with the
 `mn_addr` prefix (see
-[address format specification](https://github.com/midnightntwrk/midnight-architecture/blob/main/components/WalletEngine/Specification.md#unshielded-payment-address)).
+[address format specification](https://github.com/midnightntwrk/midnight-architecture/blob/dc972159711251a1a7c073b3e0aa9982058b7131/components/WalletEngine/Specification.md#unshielded-payment-address)).
 Address derivation for Schnorr keys is also unchanged: `SHA-256(verifying_key)`, where
 `verifying_key` is the 32-byte BIP-340 x-only public key. ECDSA addresses are derived by prefixing
 the compressed SEC1 verifying key with a domain separator: `SHA-256("mn:ecdsa:" ‖ verifying_key)`,
@@ -108,8 +108,8 @@ Signatures and verifying keys appear in the following transaction structures: cl
 transactions, unshielded offers, UTXO spends, UTXO outputs (via the recorded owner address),
 contract maintenance authorities (set on contract deploy and updatable via maintenance updates), and
 contract maintenance updates (see
-[Midnight Ledger Specification](https://github.com/midnightntwrk/midnight-ledger/tree/main/spec) for
-reference):
+[Midnight Ledger Specification](https://github.com/midnightntwrk/midnight-ledger/tree/730dba0875e75bb317e3ac81200326ef634249be/spec)
+for reference):
 
 ```rust
 struct ClaimRewardsTransaction {
@@ -185,10 +185,10 @@ The ledger validation rules are extended as follows:
 
 ### DApp Connector API
 
-[The DApp Connector API](https://github.com/midnightntwrk/midnight-dapp-connector-api/) requires a
-single change: the return type of `signData` is extended with a `scheme` discriminator identifying
-the signature scheme used. The field is initially optional, with the default value `schnorr_bip340`;
-a future major version bump of the API will make it mandatory.
+[The DApp Connector API](https://github.com/midnightntwrk/midnight-dapp-connector-api/blob/dc772165869a62bd0c9b3a8f1389956a0e9f8b5c/SPECIFICATION.md)
+requires a single change: the return type of `signData` is extended with a `scheme` discriminator
+identifying the signature scheme used. The field is initially optional, with the default value
+`schnorr_bip340`; a future major version bump of the API will make it mandatory.
 
 ```typescript
 export type Signature = {
@@ -363,15 +363,15 @@ the same test vectors — should be exercised via the integration test suite.
 - [SEC 1 v2 — Elliptic Curve Cryptography](https://www.secg.org/sec1-v2.pdf)
 - [RFC 6979 — Deterministic Usage of DSA and ECDSA](https://datatracker.ietf.org/doc/html/rfc6979)
 - [ADR-0017 — Signature scheme](https://github.com/midnightntwrk/midnight-architecture/blob/main/adrs/0017-signature-scheme.md)
-- [Midnight Wallet Specification](https://github.com/midnightntwrk/midnight-architecture/blob/main/components/WalletEngine/Specification.md)
-- [Midnight Ledger Specification](https://github.com/midnightntwrk/midnight-ledger/tree/main/spec),
+- [Midnight Wallet Specification](https://github.com/midnightntwrk/midnight-architecture/blob/dc972159711251a1a7c073b3e0aa9982058b7131/components/WalletEngine/Specification.md#unshielded-payment-address)
+- [Midnight Ledger Specification](https://github.com/midnightntwrk/midnight-ledger/tree/730dba0875e75bb317e3ac81200326ef634249be/spec),
   most notably
-  [transaction structure](https://github.com/midnightntwrk/midnight-ledger/blob/main/spec/intents-transactions.md)
+  [transaction structure](https://github.com/midnightntwrk/midnight-ledger/blob/730dba0875e75bb317e3ac81200326ef634249be/spec/intents-transactions.md)
   and
-  [preliminaries](https://github.com/midnightntwrk/midnight-ledger/blob/main/spec/preliminaries.md)
+  [preliminaries](https://github.com/midnightntwrk/midnight-ledger/blob/730dba0875e75bb317e3ac81200326ef634249be/spec/preliminaries.md)
 - [Midnight DApp Connector API](https://github.com/midnightntwrk/midnight-dapp-connector-api) and
   its
-  [specification](https://github.com/midnightntwrk/midnight-dapp-connector-api/blob/main/SPECIFICATION.md)
+  [specification](https://github.com/midnightntwrk/midnight-dapp-connector-api/blob/dc772165869a62bd0c9b3a8f1389956a0e9f8b5c/SPECIFICATION.md)
 
 ## Acknowledgements
 

--- a/mips/mip-0003-ecdsa-support.md
+++ b/mips/mip-0003-ecdsa-support.md
@@ -70,9 +70,10 @@ with 32-byte components, and 32-byte signing keys.
 
 ### Key management
 
-A new role value (`4`) is introduced in the key derivation hierarchy. This allows a single wallet to
-derive both Schnorr and ECDSA keys under the same account while keeping key material for the two
-schemes strictly separated:
+A new role value (`4`) is introduced in the key derivation hierarchy (see
+[key management specification](https://github.com/midnightntwrk/midnight-architecture/blob/main/components/WalletEngine/Specification.md#key-management)).
+This allows a single wallet to derive both Schnorr and ECDSA keys under the same account while
+keeping key material for the two schemes strictly separated:
 
 ```
 m / 44' / 2400' / account' / role / index
@@ -93,19 +94,22 @@ is the compressed SEC1 encoding of a secp256k1 point.
 ### Address generation
 
 The user-facing address format for unshielded tokens is unchanged: Bech32m encoding with the
-`mn_addr` prefix. Address derivation for Schnorr keys is also unchanged: `SHA-256(verifying_key)`,
-where `verifying_key` is the 32-byte BIP-340 x-only public key. ECDSA addresses are derived by
-prefixing the compressed SEC1 verifying key with a domain separator:
-`SHA-256("mn:ecdsa:" ‖ verifying_key)`, where `verifying_key` is the 33-byte compressed SEC1
-encoding. This keeps the address format identical at the wire level (32 bytes) but binds each
-address to a specific authorization scheme.
+`mn_addr` prefix (see
+[address format specification](https://github.com/midnightntwrk/midnight-architecture/blob/main/components/WalletEngine/Specification.md#unshielded-payment-address)).
+Address derivation for Schnorr keys is also unchanged: `SHA-256(verifying_key)`, where
+`verifying_key` is the 32-byte BIP-340 x-only public key. ECDSA addresses are derived by prefixing
+the compressed SEC1 verifying key with a domain separator: `SHA-256("mn:ecdsa:" ‖ verifying_key)`,
+where `verifying_key` is the 33-byte compressed SEC1 encoding. This keeps the address format
+identical at the wire level (32 bytes) but binds each address to a specific authorization scheme.
 
 ### Transaction format and signature verification
 
 Signatures and verifying keys appear in the following transaction structures: claim-rewards
 transactions, unshielded offers, UTXO spends, UTXO outputs (via the recorded owner address),
 contract maintenance authorities (set on contract deploy and updatable via maintenance updates), and
-contract maintenance updates:
+contract maintenance updates (see
+[Midnight Ledger Specification](https://github.com/midnightntwrk/midnight-ledger/tree/main/spec) for
+reference):
 
 ```rust
 struct ClaimRewardsTransaction {
@@ -181,9 +185,10 @@ The ledger validation rules are extended as follows:
 
 ### DApp Connector API
 
-The DApp Connector API requires a single change: the return type of `signData` is extended with a
-`scheme` discriminator identifying the signature scheme used. The field is initially optional, with
-the default value `schnorr_bip340`; a future major version bump of the API will make it mandatory.
+[The DApp Connector API](https://github.com/midnightntwrk/midnight-dapp-connector-api/) requires a
+single change: the return type of `signData` is extended with a `scheme` discriminator identifying
+the signature scheme used. The field is initially optional, with the default value `schnorr_bip340`;
+a future major version bump of the API will make it mandatory.
 
 ```typescript
 export type Signature = {
@@ -358,6 +363,15 @@ the same test vectors — should be exercised via the integration test suite.
 - [SEC 1 v2 — Elliptic Curve Cryptography](https://www.secg.org/sec1-v2.pdf)
 - [RFC 6979 — Deterministic Usage of DSA and ECDSA](https://datatracker.ietf.org/doc/html/rfc6979)
 - [ADR-0017 — Signature scheme](https://github.com/midnightntwrk/midnight-architecture/blob/main/adrs/0017-signature-scheme.md)
+- [Midnight Wallet Specification](https://github.com/midnightntwrk/midnight-architecture/blob/main/components/WalletEngine/Specification.md)
+- [Midnight Ledger Specification](https://github.com/midnightntwrk/midnight-ledger/tree/main/spec),
+  most notably
+  [transaction structure](https://github.com/midnightntwrk/midnight-ledger/blob/main/spec/intents-transactions.md)
+  and
+  [preliminaries](https://github.com/midnightntwrk/midnight-ledger/blob/main/spec/preliminaries.md)
+- [Midnight DApp Connector API](https://github.com/midnightntwrk/midnight-dapp-connector-api) and
+  its
+  [specification](https://github.com/midnightntwrk/midnight-dapp-connector-api/blob/main/SPECIFICATION.md)
 
 ## Acknowledgements
 


### PR DESCRIPTION
The discussion (https://github.com/midnightntwrk/midnight-improvement-proposals/discussions/129#discussioncomment-17135693) surfaced lack of references to relevant existing documents specifying the areas the MIP-003 (ECDSA Support) requires to change. 

This PR provides necessary links both in the body of the MIP, as well as at the references section. 