### PR TITLE
MIP-0012: contract-recipient circuit returns the sent coin

### DIFF
--- a/mips/mip-0012-native-asset-custody.md
+++ b/mips/mip-0012-native-asset-custody.md
@@ -373,7 +373,19 @@ The baseline spend circuit's recipient type is deliberately
 contract-recipient spend circuit (recipient type `ContractAddress`) for
 the direct transfer mode of section 6.6; its output MUST be claimed by
 the receiving contract in the same transaction, and its onward change
-handling is identical to the baseline circuit's.
+handling is identical to the baseline circuit's. Unlike the baseline
+circuit, it MUST return the sent coin description alongside the
+surviving change:
+
+```compact
+): [ShieldedCoinInfo, Maybe<ShieldedCoinInfo>]  // [sent, change]
+```
+
+The send evolves the coin's nonce, so the sent description exists only
+inside the circuit; the composing client needs it to build the
+receiving contract's claim call and the sealed inbox entry of the same
+transaction. Return values travel in the communication commitment
+(item 4 above), so nothing additional is disclosed.
 
 #### 6.4 InboxEntry format
 


### PR DESCRIPTION
# MIP-0012: contract-recipient circuit returns the sent coin

## What

One normative addition to the final paragraph of section 6.3: the
optional contract-recipient spend circuit MUST return the sent coin
description alongside the surviving change,
`[ShieldedCoinInfo, Maybe<ShieldedCoinInfo>]`.

## Why

Found while validating the direct transfer mode of section 6.6 end to
end in the reference implementation. The in-circuit send evolves the
coin's nonce, so the sent coin's description exists only inside the
circuit. The direct transfer is composed client-side into one
transaction (the claim MUST pair in the same transaction), and the
composing client needs the evolved description twice:

- to build the receiving contract's claim call, which must reference
  the sent coin exactly (nonce, color, value); and
- to seal the InboxEntry of section 6.4 for the receiving account,
  whose owner cannot spend the coin without its nonce.

Without the return value the client would have to re-derive the nonce
evolution off-chain, duplicating ledger internals. Circuit return
values travel in the transaction's communication commitment (section
6.3 item 4), so returning the sent description discloses nothing
additional.

The signature is validated on a local network: a composed transaction
pairing the contract-recipient spend with the payee's deposit claim
lands `SucceedEntirely`, with the claim and the inbox entry both built
from the returned sent coin.
