### PR TITLE
MIP-0013: unconditional DST derivation for per-circuit tags

### DIFF
--- a/mips/mip-0013-account-authorisation.md
+++ b/mips/mip-0013-account-authorisation.md
@@ -305,11 +305,14 @@ const c: Field = h as Field;
 
 where:
 
-- `DST_CIRCUIT` is a per-circuit domain-separation tag of the form
-  `"midnight:account:auth:v1:<circuit-name>"`, zero-padded or hashed to
-  32 bytes, distinct for every gated circuit and registered under the
-  MPS-0027 registry. Distinct tags make signatures for one circuit
-  unusable for any other, independent of argument encoding.
+- `DST_CIRCUIT` is a per-circuit domain-separation tag: the
+  `persistentHash` of the ASCII tag
+  `"midnight:account:auth:v1:<circuit-name>"` zero-padded to 64 bytes
+  (`persistentHash<[Bytes<64>]>`), regardless of the tag's length. Tags
+  MUST NOT exceed 64 bytes, are distinct for every gated circuit, and
+  are registered under the MPS-0027 registry. Distinct tags make
+  signatures for one circuit unusable for any other, independent of
+  argument encoding.
 - `kernel.self()` is the account's own contract address. Its inclusion
   makes a signature for one account unusable against another account
   in which the same device key is registered.


### PR DESCRIPTION
# MIP-0013: unconditional DST derivation for per-circuit tags

## What

One normative change to the `DST_CIRCUIT` bullet of section 5.1: the
per-circuit domain-separation tag is derived unconditionally as
`persistentHash<[Bytes<64>]>` of the ASCII tag zero-padded to 64 bytes,
regardless of the tag's length, with a 64-byte ceiling on registered
tags. The fixed short tag of section 3 (`DST_DEVICE`, 26 bytes, plain
zero-padding) is unchanged.

## Why

The previous wording ("zero-padded or hashed to 32 bytes") left three
things open, found while implementing the reference implementation:

- **Arm selection.** No condition said when a tag is padded and when it
  is hashed. Every current circuit name produces a tag over 32 bytes,
  so the ambiguity is latent today; the first short circuit name (for
  example a 7-character name under the 25-byte prefix) would make it
  live. One implementation padding and another hashing derive different
  DSTs, hence different challenges, and every signature fails as
  invalid with no diagnostic pointing at the cause.
- **Hash function.** The hash arm named no function.
- **Pre-hash encoding.** The digest of `persistentHash` depends on the
  declared preimage type, so the padding width before hashing must be
  pinned for the derivation to be single-valued.

Removing the conditional entirely is the simplest closure: one
derivation, no length case in any signer, and the DST remains one
32-byte word in the challenge preimage. The 64-byte pre-hash width
gives headroom over the longest current tag (54 bytes); network-bound
tags that would exceed the ceiling use the explicit-element route
section 5.1 already provides.

This is the construction the reference implementation validates on a
local network, including bit-exact reproduction of every per-circuit
DST by an independent Rust signer built on the ledger's own crates.
