### PR TITLE
MIP-0013: bootstrap the initial device entry post-deploy

### DIFF
--- a/mips/mip-0013-account-authorisation.md
+++ b/mips/mip-0013-account-authorisation.md
@@ -237,9 +237,39 @@ commitment, which is a fixed pseudonym disclosed on every call; a
 rolling entry is disclosed at most twice, once when inserted and once
 when consumed (Rationale R8, Security Considerations S4).
 
-The account is deployed with an initial device set of exactly one
-entry at epoch 0 and use counter 0, `device_count = 1`, and
-`auth_nonce = 0`.
+The entry construction carries a bootstrap constraint: a contract's
+address is derived from the deploy transaction's content, so no
+deploy-time code can know it, and `kernel.self()` evaluates to the
+zero address inside a constructor. The initial entry therefore cannot
+be computed at deploy time. An account is deployed dormant and
+activated by its first call:
+
+- The constructor takes a **boot commitment**
+
+  ```compact
+  persistentHash<[Bytes<32>, Bytes<32>, JubjubPoint]>([DST_BOOT, salt, pk])
+  ```
+
+  where `DST_BOOT` is the tag `"midnight:account:boot:v1"` zero-padded
+  to 32 bytes and `salt` is 32 bytes fresh per account, and stores it
+  with an empty device set, `device_count = 0`, and `auth_nonce = 0`.
+  Gated circuits are unusable before activation, and assets deposited
+  in the gap are releasable only by the committed key.
+- A permissionless circuit `activate_initial_device(pk, salt)`
+  asserts the account is not yet activated, recomputes the commitment
+  from its arguments and asserts it matches the stored one, inserts
+  the device entry for `pk` at epoch 0 and use counter 0, sets
+  `device_count = 1`, and burns the commitment. Activation is
+  deterministic in the committed key: a front-runner replaying an
+  observed `(pk, salt)` can only install the key the deployer
+  committed to, so the call needs no authorisation.
+- The salt MUST be fresh per account. Without it the commitment is a
+  stable function of the device key alone, equal across every account
+  the same key deploys, and pre-activation state would link a user's
+  accounts (the property the address-bound entries exist to prevent).
+
+Deployment and activation SHOULD be submitted back to back; the
+account is usable once both are final.
 
 ### 4. Seam instantiation
 
@@ -961,6 +991,10 @@ Conformance is demonstrated by a suite exercising, against a real node:
 9. **Non-exfiltration audit**: the proving pipeline's inputs for every
    gated call are enumerated and contain no device private key or key
    share (AUTH-4).
+10. **Bootstrap**: activation with the committed `(pk, salt)` succeeds
+    and installs the entry at epoch 0 and use counter 0; a second
+    activation aborts; an activation whose arguments do not match the
+    commitment aborts (section 3).
 
 ## References (Optional)
 


### PR DESCRIPTION
# MIP-0013: bootstrap the initial device entry post-deploy

## What

Section 3 stated that the account "is deployed with an initial device
set of exactly one entry". This replaces that with a two-step
bootstrap, and appends one conformance test (test 10) covering it:

- the constructor stores a salted **boot commitment**
  `persistentHash([DST_BOOT, salt, pk])` with an empty device set;
- a permissionless `activate_initial_device(pk, salt)` circuit matches
  the commitment, installs the entry at epoch 0 and use counter 0, and
  burns the commitment.

## Why

The deploy-time entry is unimplementable in principle, not merely on
the current toolchain. A device entry binds `kernel.self()`, but the
contract address is derived from the deploy transaction's content, so
no deploy-time code can know it; `kernel.self()` evaluates to the zero
address inside a constructor. We verified the failure empirically: an
entry computed in the constructor silently binds the zero address, can
never match a client's address-bound derivation, and bricks the
account with no recovery path.

Dropping the address from the entry derivation instead would be a
privacy regression: entries are disclosed when consumed and inserted,
and the address is what makes the same device key produce different
entry values in different accounts. The two-step deploy is the cost of
unlinkable entries, paid once per account.

The bootstrap is safe to leave permissionless: activation is
deterministic in the committed key, so a front-runner replaying an
observed `(pk, salt)` can only install the key the deployer committed
to. The fresh per-account salt keeps pre-activation state free of
cross-account-stable values. Gated circuits are unusable before
activation, and assets deposited in the gap are releasable only by the
committed key.

This is the pattern the reference implementation validates end to end
on a local network.
