### PR TITLE
deployments/veilcore: correct the record after approval

### DIFF
--- a/deployments/veilcore.md
+++ b/deployments/veilcore.md
@@ -6,9 +6,10 @@
 
 VeilCore records who held a plant cultivar and when, without anyone disclosing the
 genetics. A record is hashed client-side; only a domain-separated commitment reaches
-the chain. The contract exposes eight circuits across two concerns: provenance
-(`anchor`, `proveOwnership`, `pairDna`) and licensing (`issueLicense`,
-`countersignLicense`, `revokeLicense`, `proveLicense`, `licenseStatus`). Genetic
+the chain. The contract exposes twelve circuits across two concerns: provenance
+(`anchor`, `anchorBatch`, `proveOwnership`, `pairDna`) and licensing
+(`issueLicense`, `countersignLicense`, `proposeTransfer`, `approveTransfer`,
+`withdrawTransfer`, `revokeLicense`, `proveLicense`, `licenseStatus`). Genetic
 preimages, licence terms and counterparties never leave the holder's device — they are
 supplied to circuits as private witnesses.
 
@@ -19,7 +20,7 @@ and no plaintext of any kind — only 32-byte commitments.
 |---|---|---|---|
 | Privacy-at-risk | 2 | Disclosed values are domain-separated hashes with no recoverable preimage and no identity linkage. A chain observer can see that an address anchored *a* commitment and when, and can correlate repeat activity by that address — timing and counterparty-shaped metadata rather than identity-level data. High-THC cannabis is a stigmatised market, so we do not claim Tier 1. No genetics, no cultivar name, no breeder identity and no licence terms are ever disclosed. | Commitments are `persistentHash` of a private witness with a domain separator; preimages stay client-side. Holders may use a fresh address per record where correlation is a concern. |
 | Value-at-risk | 1 | The contract holds no funds. No tokens are deposited, escrowed, pooled or transferred by any circuit. An exploit could produce an incorrect commitment or licence state, not a loss of principal. | N/A |
-| State-space-at-risk | 2 | Anchoring is bounded by design and writes **no per-record state**: `anchor`, `proveOwnership` and `pairDna` disclose into the transaction and touch only fixed single-slot fields. One million records add nothing beyond three slots. Licensing retains state only for **live** agreements — `revokeLicense` removes both map entries, so growth is bounded by open business rather than cumulative usage, with clearing initiated by the party who created the entry. | See *Known limitation* below, disclosed rather than omitted. |
+| State-space-at-risk | 2 | Anchoring is bounded by design and writes **no per-record state**: `anchor`, `proveOwnership` and `pairDna` disclose into the transaction and touch only fixed single-slot fields. One million records add nothing beyond three slots. Licensing retains state only for **live** agreements — `revokeLicense` removes all four map entries, including any open transfer proposal, so growth is bounded by open business rather than cumulative usage, with clearing initiated by the party who created the entry. | See *Known limitation* below, disclosed rather than omitted. |
 
 ---
 
@@ -29,11 +30,18 @@ and no plaintext of any kind — only 32-byte commitments.
 export ledger anchorSeq: Counter;                              // fixed
 export ledger lastAnchor: Bytes<32>;                           // fixed
 export ledger proofSeq: Counter;                               // fixed
+export ledger batchSeq: Counter;                               // fixed
+export ledger lastBatchRoot: Bytes<32>;                        // fixed
+export ledger transferSeq: Counter;                            // fixed
+export ledger pendingTransferOf: Map<Bytes<32>, Bytes<32>>;    // open proposals only
+export ledger licenseHolderOf: Map<Bytes<32>, Bytes<32>>;      // live licences only
 export ledger licenseStatusOf: Map<Bytes<32>, LicenseState>;   // live licences only
 export ledger licenseRecordOf: Map<Bytes<32>, Bytes<32>>;      // live licences only
 ```
 
-Three fixed slots and two maps cleared by the circuit that filled them.
+Six fixed slots and four maps cleared by the circuits that filled them. A licence
+holds at most one open transfer proposal at a time, and `revokeLicense` clears the
+proposal along with the licence.
 
 ## Why anchoring writes no state
 
@@ -91,8 +99,9 @@ historical context and is **not** the subject of this request.
 - **Compact source:** `contract/src/veilcore.compact`
 - **compactc:** 0.31.1 · **language version:** 0.23
 - **Build:** `compact compile src/veilcore.compact ./src/managed/veilcore`
-- **Circuits:** `commit` (pure) · `anchor` · `proveOwnership` · `pairDna` ·
-  `issueLicense` · `countersignLicense` · `revokeLicense` · `proveLicense` ·
+- **Circuits:** `commit` (pure) · `anchor` · `anchorBatch` · `proveOwnership` ·
+  `pairDna` · `issueLicense` · `countersignLicense` · `proposeTransfer` ·
+  `approveTransfer` · `withdrawTransfer` · `revokeLicense` · `proveLicense` ·
   `licenseStatus`
 - **Witness:** `localGeneticSecret()`
 - **Design notes:** `docs/design.md` in the repository
@@ -101,25 +110,72 @@ SHA-256 of compiled artefacts (`contract/src/managed/veilcore/`):
 
 | File | SHA-256 |
 |---|---|
-| `keys/anchor.prover` | `a4faa36ae7df32e1d93a7306743c4614417f79ef986ccb59d009a592a91d154f` |
-| `keys/anchor.verifier` | `ded343e7eb21a4dc4fbf2b0968020a78e6bd3f35e011badfcfd399e5a0930dd8` |
-| `keys/proveOwnership.prover` | `ea345c18b31d593ea364bfa625942e969e80072e87ce16bc863d861b2e02ad6a` |
-| `keys/proveOwnership.verifier` | `f4546dce72170047e0205d2350ad60e1b8d47ce39c021b35c48468823b83d424` |
-| `keys/pairDna.prover` | `75fdab3affffb26d895743f3944bb61e5af8b8905ab9c075ad815654bf9f7739` |
-| `keys/pairDna.verifier` | `82239caa00d04357d67aee25d7c961542f4ac4f9e1ae7876ad0e35732649c5fa` |
-| `keys/issueLicense.prover` | `43c571c5019e51fe760333484c331120de092b2d0b60bd9802aa27caef685ee0` |
-| `keys/issueLicense.verifier` | `f54af8b124a11c6b32b5ef1d80a33657ebc4e283f620f8dfd15e8725efa43ac9` |
-| `keys/countersignLicense.prover` | `a6ca0f2bd609f64e563e7bae8baf3ca5ea4f3bc3480e438d95c98b04bb0d11e3` |
-| `keys/countersignLicense.verifier` | `15412d166a9fdfeed5e5d6eaf422b6c000f0533f5a97234c72063ade20d7582f` |
-| `keys/revokeLicense.prover` | `91ec53c373a6ffc4c9b901020b14a82640ca88e3366653621bf97e340706e3dd` |
-| `keys/revokeLicense.verifier` | `272da16855ad5b879fb729cda19f1d37c549237fd55826751ae5bd5bf1a1cf24` |
-| `keys/proveLicense.prover` | `0797c0d90097cf39d8c4c064ed279efa2986b81c5f801c42d384a15ab0d2e84a` |
-| `keys/proveLicense.verifier` | `b97e34785d555b2ea93e05ab1007acf3f7cd61cd2f410c26a7d048dae348619f` |
-| `keys/licenseStatus.prover` | `a7a5b354733108075915375bccf751e07e24dcf78d55ac218e7289ab6e510f7a` |
-| `keys/licenseStatus.verifier` | `79682302bbc3f843f22b26aff54efc95a4405f717fe998ea8c4ac9d4e0ef6284` |
+| `keys/anchor.prover` | `a4faa36ae7df32e1d93a7306743c4614417f79ef986ccb59d009a592a91d154f` |  <!-- unchanged since approval -->
+| `keys/anchor.verifier` | `ded343e7eb21a4dc4fbf2b0968020a78e6bd3f35e011badfcfd399e5a0930dd8` |  <!-- unchanged since approval -->
+| `keys/anchorBatch.prover` | `785faa21fa5b1105554a012e46ddceff34adff95b0c2a941e1bb55f23892bdf4` |
+| `keys/anchorBatch.verifier` | `fe662bf56906d169dd03dc5ab21ad8684a57274ab4f162726fa75ad9d7e6a9c9` |
+| `keys/proveOwnership.prover` | `ea345c18b31d593ea364bfa625942e969e80072e87ce16bc863d861b2e02ad6a` |  <!-- unchanged since approval -->
+| `keys/proveOwnership.verifier` | `f4546dce72170047e0205d2350ad60e1b8d47ce39c021b35c48468823b83d424` |  <!-- unchanged since approval -->
+| `keys/pairDna.prover` | `75fdab3affffb26d895743f3944bb61e5af8b8905ab9c075ad815654bf9f7739` |  <!-- unchanged since approval -->
+| `keys/pairDna.verifier` | `82239caa00d04357d67aee25d7c961542f4ac4f9e1ae7876ad0e35732649c5fa` |  <!-- unchanged since approval -->
+| `keys/issueLicense.prover` | `3b86e79ca846a4d2499f5c495f6b4d6155471c646ef04253b0599b3fcf7e5082` |
+| `keys/issueLicense.verifier` | `97a546ab71b2925c8794e366b6712e12002b80f4c05a2e9fbf0ceb5ac063d9e4` |
+| `keys/countersignLicense.prover` | `d7901d8ad34e53cf88d9098b55537aef545d673751a28a6ff7ee86c4433b74fc` |
+| `keys/countersignLicense.verifier` | `dae83066ccf2781725d41a2edd292f12c178c782f701fb79244fb91f3701506a` |
+| `keys/proposeTransfer.prover` | `083a73217d359e4870fd8caf37e9501e0ec8f6837abcc02261cff83958084cc8` |
+| `keys/proposeTransfer.verifier` | `c759c60f0fbd0062de980efd559819b5a7f0aebb1123b4ca39f3fd01bb6e8c7a` |
+| `keys/approveTransfer.prover` | `40554b1b99996729a3575c8a0e34b0189b518262930b792a65bf270da9ebfe7d` |
+| `keys/approveTransfer.verifier` | `761b019e6c355dddb20605488f2392bd087a66a28ddada3488428ec48111758b` |
+| `keys/withdrawTransfer.prover` | `760e2a98d06afa47f51be04270d5e2bdd7d86b461dedda50aff27923931a4ed9` |
+| `keys/withdrawTransfer.verifier` | `2cc689a5b9b14dc3ec6738aca655b3dd177b495f0770429d6b5f13cbec6e8207` |
+| `keys/revokeLicense.prover` | `088c0bf340fd3eb1871a4ba11c4698738d870a51c780697d5c8efe9826293759` |
+| `keys/revokeLicense.verifier` | `c8723a5229e869d15164587738f4acd08e26eee523a7ba62b8b74fce82cad983` |
+| `keys/proveLicense.prover` | `b8ef539e8c04bf11310c1217e870e9c9cde14dc50bcdea94372f10542a95e832` |
+| `keys/proveLicense.verifier` | `24776b152dbc4b37a2092eb77131b35dc7f3fe81bee805f23d75f415d807bdb0` |
+| `keys/licenseStatus.prover` | `3642dc89f199b94de9899d9bdb53bb2335aca67d8438a99a4c24b57f0827552b` |
+| `keys/licenseStatus.verifier` | `26e6485f52de2868ac087a395553537efbdd496189896e3b6a5a9cd0a5d849e8` |
 
 Reviewers can reproduce these by running the build command above and comparing
 fingerprints.
+
+## Revision — 24 August 2026
+
+**This document has been corrected after approval, and the subject has grown since
+then.** It is recorded here rather than amended silently, because a deployment record
+that no longer describes the contract it authorises is worth less than one that says so.
+
+At approval the contract exposed eight circuits. It now exposes twelve. Added since:
+`anchorBatch` (batch root anchoring, so one transaction timestamps many records and no
+holder needs a wallet), and `proposeTransfer` / `approveTransfer` / `withdrawTransfer`
+(permissioned licence transfer — a licence is not a bearer instrument, so the holder
+proposes and the issuer approves).
+
+**Four authorisation defects were found in the licensing circuits and fixed.** Max Weber
+(ODATANO / NIGHTGATE) compiled the contract, deployed it to preprod, ran every circuit
+and replayed them as an attacker, reporting each finding with a transaction hash:
+[issue #22](https://github.com/hunterincoming/veilcore-midnight-testnet/issues/22).
+
+- `countersignLicense`, `withdrawTransfer` and `proposeTransfer` took the licence
+  commitment as a public argument. That commitment is disclosed by `issueLicense` and is
+  a key in a public map, so any observer could activate, cancel or propose against any
+  licence. All three now take the secret as a private argument and derive the
+  commitment, which is what `proveLicense` already did.
+- `approveTransfer` read whichever proposal was pending at execution time. A proposal
+  the issuer had seen could be replaced before approval, moving the licence to a party
+  the issuer never agreed to. It now names the expected recipient, and `proposeTransfer`
+  refuses to overwrite a standing proposal.
+- `revokeLicense` left the pending transfer entry behind, contradicting the
+  bounded-state claim made above.
+
+The four attacks are retained as regression tests in `contract/test-contract.mjs`: each
+passed against the contract as reviewed and each must fail against it now.
+
+**The provenance circuits are unchanged.** `anchor`, `proveOwnership` and `pairDna`
+carry the same artefact fingerprints as at approval, marked in the table above. Every
+changed fingerprint is licensing.
+
+**Nothing has been deployed to mainnet.** The key has not been requested. We would
+rather this document, the review, and the deployed bytes agree before it is.
 
 ## Notes
 

--- a/deployments/veilcore.md
+++ b/deployments/veilcore.md
@@ -142,7 +142,7 @@ SHA-256 of compiled artefacts (`contract/src/managed/veilcore/`):
 Reviewers can reproduce these by running the build command above and comparing
 fingerprints.
 
-## Revision — 24 August 2026
+## Revision — 24–25 August 2026
 
 **This document has been corrected after approval, and the subject has grown since
 then.** It is recorded here rather than amended silently, because a deployment record
@@ -151,25 +151,31 @@ that no longer describes the contract it authorises is worth less than one that 
 At approval the contract exposed eight circuits. It now exposes twelve. Added since:
 `anchorBatch` (batch root anchoring, so one transaction timestamps many records and no
 holder needs a wallet), and `proposeTransfer` / `approveTransfer` / `withdrawTransfer`
-(permissioned licence transfer — a licence is not a bearer instrument, so the holder
-proposes and the issuer approves).
+(licence assignment — a licence is not a bearer instrument, so the holder proposes and
+the issuer consents to a named party. See the second correction below: the mechanism as
+first written did not achieve this).
 
 **Four authorisation defects were found in the licensing circuits and fixed.** Max Weber
 (ODATANO / NIGHTGATE) compiled the contract, deployed it to preprod, ran every circuit
 and replayed them as an attacker, reporting each finding with a transaction hash:
 [issue #22](https://github.com/hunterincoming/veilcore-midnight-testnet/issues/22).
 
-- `countersignLicense`, `withdrawTransfer` and `proposeTransfer` took the licence
-  commitment as a public argument. That commitment is disclosed by `issueLicense` and is
-  a key in a public map, so any observer could activate, cancel or propose against any
-  licence. All three now take the secret as a private argument and derive the
-  commitment, which is what `proveLicense` already did.
-- `approveTransfer` read whichever proposal was pending at execution time. A proposal
-  the issuer had seen could be replaced before approval, moving the licence to a party
-  the issuer never agreed to. It now names the expected recipient, and `proposeTransfer`
-  refuses to overwrite a standing proposal.
-- `revokeLicense` left the pending transfer entry behind, contradicting the
-  bounded-state claim made above.
+1. `countersignLicense` took the licence commitment as a public argument. That
+   commitment is disclosed by `issueLicense` and is a key in a public map, so any
+   observer could activate any pending licence — which removes the bilateral property
+   rather than weakening it.
+2. `proposeTransfer` was unauthenticated and its write overwrote, so a stranger could
+   replace a pending proposal; `approveTransfer` then read whichever proposal was
+   pending at execution time, so a proposal the issuer had seen could be swapped before
+   approval. Demonstrated in three preprod transactions.
+3. `withdrawTransfer` authenticated nobody, so any observer could cancel any pending
+   proposal and block an assignment indefinitely.
+4. `revokeLicense` left the pending transfer entry behind, contradicting the
+   bounded-state claim made above.
+
+The first three now take the licence secret as a private argument and derive the
+commitment, which is what `proveLicense` already did. `approveTransfer` names the party
+it is approving, and `proposeTransfer` refuses to overwrite a standing proposal.
 
 The four attacks are retained as regression tests in `contract/test-contract.mjs`: each
 passed against the contract as reviewed and each must fail against it now.
@@ -178,7 +184,7 @@ passed against the contract as reviewed and each must fail against it now.
 carry the same artefact fingerprints as at approval, marked in the table above. Every
 changed fingerprint is licensing.
 
-**A second correction, the same day.** Reading the whole contract after the four
+**A second correction, the following morning.** Reading the whole contract after the four
 fixes turned up a fifth problem, in the transfer mechanism itself rather than in
 its authorisation.
 

--- a/deployments/veilcore.md
+++ b/deployments/veilcore.md
@@ -20,7 +20,7 @@ and no plaintext of any kind — only 32-byte commitments.
 |---|---|---|---|
 | Privacy-at-risk | 2 | Disclosed values are domain-separated hashes with no recoverable preimage and no identity linkage. A chain observer can see that an address anchored *a* commitment and when, and can correlate repeat activity by that address — timing and counterparty-shaped metadata rather than identity-level data. High-THC cannabis is a stigmatised market, so we do not claim Tier 1. No genetics, no cultivar name, no breeder identity and no licence terms are ever disclosed. | Commitments are `persistentHash` of a private witness with a domain separator; preimages stay client-side. Holders may use a fresh address per record where correlation is a concern. |
 | Value-at-risk | 1 | The contract holds no funds. No tokens are deposited, escrowed, pooled or transferred by any circuit. An exploit could produce an incorrect commitment or licence state, not a loss of principal. | N/A |
-| State-space-at-risk | 2 | Anchoring is bounded by design and writes **no per-record state**: `anchor`, `proveOwnership` and `pairDna` disclose into the transaction and touch only fixed single-slot fields. One million records add nothing beyond three slots. Licensing retains state only for **live** agreements — `revokeLicense` removes all four map entries, including any open transfer proposal, so growth is bounded by open business rather than cumulative usage, with clearing initiated by the party who created the entry. | See *Known limitation* below, disclosed rather than omitted. |
+| State-space-at-risk | 2 | Anchoring is bounded by design and writes **no per-record state**: `anchor`, `proveOwnership` and `pairDna` disclose into the transaction and touch only fixed single-slot fields. One million records add nothing beyond three slots. Licensing retains state only for **live** agreements — `revokeLicense` removes all three map entries, including any open assignment proposal, so growth is bounded by open business rather than cumulative usage, with clearing initiated by the party who created the entry. An approved assignment is net neutral: one licence is removed and one inserted. | See *Known limitation* below, disclosed rather than omitted. |
 
 ---
 
@@ -34,14 +34,18 @@ export ledger batchSeq: Counter;                               // fixed
 export ledger lastBatchRoot: Bytes<32>;                        // fixed
 export ledger transferSeq: Counter;                            // fixed
 export ledger pendingTransferOf: Map<Bytes<32>, Bytes<32>>;    // open proposals only
-export ledger licenseHolderOf: Map<Bytes<32>, Bytes<32>>;      // live licences only
 export ledger licenseStatusOf: Map<Bytes<32>, LicenseState>;   // live licences only
 export ledger licenseRecordOf: Map<Bytes<32>, Bytes<32>>;      // live licences only
 ```
 
-Six fixed slots and four maps cleared by the circuits that filled them. A licence
-holds at most one open transfer proposal at a time, and `revokeLicense` clears the
-proposal along with the licence.
+Six fixed slots and three maps cleared by the circuits that filled them. A licence
+holds at most one open assignment proposal at a time; `revokeLicense` clears the
+proposal along with the licence, and an approved assignment removes the old
+licence entirely.
+
+**The map key is the holder.** Only a party who knows the secret behind a licence
+commitment can act on that licence, so there is no separate holder field and none
+can drift out of step with who actually controls it.
 
 ## Why anchoring writes no state
 
@@ -118,22 +122,22 @@ SHA-256 of compiled artefacts (`contract/src/managed/veilcore/`):
 | `keys/proveOwnership.verifier` | `f4546dce72170047e0205d2350ad60e1b8d47ce39c021b35c48468823b83d424` |  <!-- unchanged since approval -->
 | `keys/pairDna.prover` | `75fdab3affffb26d895743f3944bb61e5af8b8905ab9c075ad815654bf9f7739` |  <!-- unchanged since approval -->
 | `keys/pairDna.verifier` | `82239caa00d04357d67aee25d7c961542f4ac4f9e1ae7876ad0e35732649c5fa` |  <!-- unchanged since approval -->
-| `keys/issueLicense.prover` | `3b86e79ca846a4d2499f5c495f6b4d6155471c646ef04253b0599b3fcf7e5082` |
-| `keys/issueLicense.verifier` | `97a546ab71b2925c8794e366b6712e12002b80f4c05a2e9fbf0ceb5ac063d9e4` |
-| `keys/countersignLicense.prover` | `d7901d8ad34e53cf88d9098b55537aef545d673751a28a6ff7ee86c4433b74fc` |
-| `keys/countersignLicense.verifier` | `dae83066ccf2781725d41a2edd292f12c178c782f701fb79244fb91f3701506a` |
-| `keys/proposeTransfer.prover` | `083a73217d359e4870fd8caf37e9501e0ec8f6837abcc02261cff83958084cc8` |
-| `keys/proposeTransfer.verifier` | `c759c60f0fbd0062de980efd559819b5a7f0aebb1123b4ca39f3fd01bb6e8c7a` |
-| `keys/approveTransfer.prover` | `40554b1b99996729a3575c8a0e34b0189b518262930b792a65bf270da9ebfe7d` |
-| `keys/approveTransfer.verifier` | `761b019e6c355dddb20605488f2392bd087a66a28ddada3488428ec48111758b` |
+| `keys/issueLicense.prover` | `bb6327ed4ac98797f069c42c4f7418238536d5c3a92a7b5a97cb45aec1e613fb` |
+| `keys/issueLicense.verifier` | `94e9563f2684222d21fb50727a0e8f0d4a622a061be9d23b50f75166c7b61b6f` |
+| `keys/countersignLicense.prover` | `e538299298e05b9920ed6fbcb52a6c3159c0d0ea0a45d4ba3018b8e31d011868` |
+| `keys/countersignLicense.verifier` | `fe8ff9309a1c88ec2c24ae0809368690c531dc467053a770b0f6a1aa321d1874` |
+| `keys/proposeTransfer.prover` | `0ac26d7531fe20ab3becc2256f88efff7a3369606623bd70ccea22539b02af7e` |
+| `keys/proposeTransfer.verifier` | `36f4dd7bbfc70690438af9c7fd604ab20368fc7f140cc485892e376d07d0ee56` |
+| `keys/approveTransfer.prover` | `dca1f920cea6197938c9c0b42557af33de3c8755036276b752d04ae50bba83ba` |
+| `keys/approveTransfer.verifier` | `5dd49df2634278757e665873917042bc5b279c1376d79b92320ac07fbe715f95` |
 | `keys/withdrawTransfer.prover` | `760e2a98d06afa47f51be04270d5e2bdd7d86b461dedda50aff27923931a4ed9` |
 | `keys/withdrawTransfer.verifier` | `2cc689a5b9b14dc3ec6738aca655b3dd177b495f0770429d6b5f13cbec6e8207` |
-| `keys/revokeLicense.prover` | `088c0bf340fd3eb1871a4ba11c4698738d870a51c780697d5c8efe9826293759` |
-| `keys/revokeLicense.verifier` | `c8723a5229e869d15164587738f4acd08e26eee523a7ba62b8b74fce82cad983` |
-| `keys/proveLicense.prover` | `b8ef539e8c04bf11310c1217e870e9c9cde14dc50bcdea94372f10542a95e832` |
-| `keys/proveLicense.verifier` | `24776b152dbc4b37a2092eb77131b35dc7f3fe81bee805f23d75f415d807bdb0` |
-| `keys/licenseStatus.prover` | `3642dc89f199b94de9899d9bdb53bb2335aca67d8438a99a4c24b57f0827552b` |
-| `keys/licenseStatus.verifier` | `26e6485f52de2868ac087a395553537efbdd496189896e3b6a5a9cd0a5d849e8` |
+| `keys/revokeLicense.prover` | `21b5e18c10da1b703950fef3e31e6958a044aa5c430d80695dca2077979ce651` |
+| `keys/revokeLicense.verifier` | `9133c4ddca10fa4e7930cf5d31a939380e5b525735a832bfa4c4121c9431242c` |
+| `keys/proveLicense.prover` | `ee6884c857cbf1403465ef2e41d547977b73cf625c072182bea91ec495db8b16` |
+| `keys/proveLicense.verifier` | `8b58154cd6b08e3d865eaa8a1cd76076a61c956e324fa54176ce36923545e805` |
+| `keys/licenseStatus.prover` | `314fb3f69e370608db2a2503db31f0c0b553c33bce2f43b7336bcd7d464b2c32` |
+| `keys/licenseStatus.verifier` | `21c9dfc7a6e9d17db8d14c1555ac306be9d4d4ab10a1a98188add2bef92aa0a6` |
 
 Reviewers can reproduce these by running the build command above and comparing
 fingerprints.
@@ -173,6 +177,33 @@ passed against the contract as reviewed and each must fail against it now.
 **The provenance circuits are unchanged.** `anchor`, `proveOwnership` and `pairDna`
 carry the same artefact fingerprints as at approval, marked in the table above. Every
 changed fingerprint is licensing.
+
+**A second correction, the same day.** Reading the whole contract after the four
+fixes turned up a fifth problem, in the transfer mechanism itself rather than in
+its authorisation.
+
+A licence's identity is the secret behind its commitment, and a secret cannot be
+un-known. `approveTransfer` reassigned a holder field, which moved nothing: the
+outgoing party still knew the secret, so they could still prove the licence and
+still propose further transfers, while the incoming party could do nothing unless
+the secret was handed over — after which both held it permanently.
+
+The USDA plant variety licence template settles the model. Assignment requires the
+licensor's prior written consent, and *the identity of the parties is material to
+the formation of this Agreement* with obligations that are *non-delegable*. So the
+old licence now ends and a new one begins: the incoming party generates their own
+secret and hands over only its commitment, the issuer consents to that specific
+commitment, and on approval the old entry is removed and a new one inserted
+against the same record. The outgoing party's rights end because the key they hold
+is no longer in the map.
+
+`licenseHolderOf` is gone with it. Four regression tests cover the property that
+replaced it: the old licence no longer exists, the outgoing party can neither
+prove it nor propose another assignment, and the incoming party can prove it.
+
+Also stated rather than enforced: **the licensee generates the licence secret** and
+gives the issuer only its commitment. An issuer who generates the secret can also
+countersign, which is a licence issued to nobody. The contract cannot check this.
 
 **Nothing has been deployed to mainnet.** The key has not been requested. We would
 rather this document, the review, and the deployed bytes agree before it is.


### PR DESCRIPTION
The contract this document describes has changed since it was approved, and four authorization defects were found in it and fixed. Rather than amend the document quietly, this records what changed and when.

What grew. Eight circuits at approval, twelve now. Added: `anchorBatch`, and `proposeTransfer` / `approveTransfer` / `withdrawTransfer` for permissioned license transfer.

What was wrong. Max Weber (ODATANO / NIGHTGATE) compiled the contract, deployed it to preprod, ran every circuit and replayed them as an attacker. Four authorization gaps in the licensing circuits, each with a transaction hash: hunterincoming/veilcore-midnight-testnet#22. All four are fixed, and the four attacks are retained as regression tests.

What did not change. `anchor`, `proveOwnership` and `pairDna` carry the same artifact fingerprints as at approval. Every changed fingerprint is licensing.

Nothing is on mainnet and the key has not been requested. I would rather this document, the review and the deployed bytes agree first.

Happy to be told this belongs in a fresh deployment request rather than a revision to this one.