### PR TITLE
feat: init site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  # Publish on every push to the default branch.
+  push:
+    branches: ["main"]
+  # Allow a manual run from the Actions tab.
+  workflow_dispatch:
+
+# Permissions required for the GitHub Pages deployment.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress production deploy.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        # Use the baseurl provided by the Pages deployment.
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,17 +23,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: "3.3"
           bundler-cache: true
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build with Jekyll
         # Use the baseurl provided by the Pages deployment.
@@ -42,7 +42,7 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
 
   deploy:
     needs: build
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 .DS_Store
 /.midnight-expert
+
+# Jekyll static site
+_site/
+.jekyll-cache/
+.jekyll-metadata
+vendor/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,17 @@
+source "https://rubygems.org"
+
+# Jekyll static-site generator for the Midnight Improvement Proposals site.
+# See: https://jekyllrb.com/
+gem "jekyll", "~> 4.3"
+
+# Theme: just-the-docs — sidebar navigation + built-in full-text search.
+# https://just-the-docs.com/
+gem "just-the-docs", "~> 0.10"
+
+group :jekyll_plugins do
+  # Rewrites in-document relative .md links to their built page URLs.
+  gem "jekyll-relative-links", "~> 0.7"
+end
+
+# Lock the platform so `bundle install` in CI resolves the same gems.
+gem "webrick", "~> 1.8"

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,69 @@
+# Jekyll configuration for the Midnight Improvement Proposals static site.
+# Deployed to GitHub Pages at https://midnightntwrk.github.io/midnight-improvement-proposals/
+
+title: Midnight Improvement Proposals
+description: >-
+  The canonical home for Midnight's open development documents — where the
+  community proposes, discusses, and records changes to the Midnight protocol,
+  standards, and ecosystem.
+
+# The site is served from a project subpath on github.io.
+url: "https://midnightntwrk.github.io"
+baseurl: "/midnight-improvement-proposals"
+
+# Theme + plugins (all resolved via the Gemfile).
+theme: just-the-docs
+plugins:
+  - jekyll-relative-links
+
+# just-the-docs options.
+search_enabled: true
+color_scheme: dark
+heading_anchors: true
+aux_links:
+  "View on GitHub":
+    - "https://github.com/midnightntwrk/midnight-improvement-proposals"
+back_to_top: true
+back_to_top_text: "Back to top"
+
+# jekyll-relative-links: turn `[...](./foo.md)` into working page links.
+relative_links:
+  enabled: true
+  collections: false
+
+# Apply the proposal layout to every rendered MIP/MPS page by path.
+# Page-level front matter (e.g. on the index pages) overrides these.
+defaults:
+  - scope:
+      path: "mips"
+    values:
+      layout: proposal
+  - scope:
+      path: "mps"
+    values:
+      layout: proposal
+
+# Files/dirs that are repo metadata, not site content.
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - vendor/
+  - LICENSE
+  - CODEOWNERS
+  - CODE_OF_CONDUCT.md
+  - SECURITY.md
+  - CHANGELOG.md
+  - CONTRIBUTING.md
+  - NUMBERS_INDEX.md
+  - ROLLING_AGENDA.md
+  - README.md
+  - .envrc
+  - .github/
+  - .midnight-expert/
+  # deployments/*.md have no front matter, so Jekyll would copy them raw.
+  # Keep them in the repo but out of the built site for now.
+  - deployments/
+  - mps/deployments/
+  # Templates are not proposals — keep them out of the rendered site.
+  - mips/mip-template.md
+  - mps/mps-template.md

--- a/_layouts/proposal.html
+++ b/_layouts/proposal.html
@@ -1,0 +1,42 @@
+---
+layout: default
+---
+
+<h1>{{ page.Title | default: page.name }}</h1>
+
+<table class="proposal-meta">
+  <tbody>
+    {% if page.MIP and page.MIP != "none" %}
+    <tr><th scope="row">MIP</th><td>{{ page.MIP }}</td></tr>
+    {% endif %}
+    {% if page.MPS and page.MPS != "none" %}
+    <tr><th scope="row">MPS</th><td>{{ page.MPS }}</td></tr>
+    {% endif %}
+    {% if page.Status %}
+    <tr><th scope="row">Status</th><td>{{ page.Status }}</td></tr>
+    {% endif %}
+    {% if page.Category %}
+    <tr><th scope="row">Category</th><td>{{ page.Category }}</td></tr>
+    {% endif %}
+    {% if page.Authors %}
+    <tr><th scope="row">Authors</th><td>
+      {%- comment -%}
+        Authors may be a YAML list (MIPs) or a plain string (MPSs).
+        `.first` is truthy for arrays, nil for strings — use it to discriminate.
+      {%- endcomment -%}
+      {% if page.Authors.first %}{{ page.Authors | join: ", " }}{% else %}{{ page.Authors }}{% endif %}
+    </td></tr>
+    {% endif %}
+    {% if page.Created %}
+    <tr><th scope="row">Created</th><td>{{ page.Created }}</td></tr>
+    {% endif %}
+    {% if page.Requires and page.Requires != "none" %}
+    <tr><th scope="row">Requires</th><td>{{ page.Requires }}</td></tr>
+    {% endif %}
+    {% if page.Replaces and page.Replaces != "none" %}
+    <tr><th scope="row">Replaces</th><td>{{ page.Replaces }}</td></tr>
+    {% endif %}
+  </tbody>
+</table>
+
+{{ content }}

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,0 +1,15 @@
+// Custom overrides for the just-the-docs theme.
+
+// The site title "Midnight Improvement Proposals" wraps to multiple lines in the
+// sidebar, but the theme locks the header to a single toolbar row height
+// (3.75rem) with vertical centering, which clips the top line ("Midnight").
+// Let the header grow to fit the full title so the whole thing is visible.
+.site-header {
+  height: auto;
+  min-height: 3.75rem;
+  max-height: none;
+}
+
+.site-title {
+  height: auto;
+}

--- a/index.md
+++ b/index.md
@@ -1,0 +1,46 @@
+---
+title: Home
+layout: default
+nav_order: 1
+---
+
+# Midnight Improvement Proposals
+
+This site is the canonical home for Midnight's open development documents — where the
+community proposes, discusses, and records changes to the Midnight protocol, standards,
+and ecosystem.
+
+**Contributions from anyone are welcome** — developers, node operators, application
+builders, token holders, and users alike. If you have an idea for improving Midnight,
+this is the place to bring it.
+
+## What lives here
+
+- **[Midnight Improvement Proposals (MIPs)]({{ "/mips/" | relative_url }})** — Concrete,
+  technically-precise proposals to change the Midnight ecosystem. MIPs propose *how* a
+  problem is solved.
+- **[Midnight Problem Statements (MPS)]({{ "/mps/" | relative_url }})** — Solution-agnostic
+  descriptions of friction, gaps, or opportunities. MPS documents define *what* needs solving.
+
+## How to contribute
+
+1. **Open a discussion first** if you'd like early feedback — via the
+   [Discussions tab](https://github.com/midnightntwrk/midnight-improvement-proposals/discussions)
+   or the [Discord](https://discord.com/invite/midnightnetwork).
+2. **Fork the repository** and copy the appropriate template (`mip-template.md` or
+   `mps-template.md`).
+3. **Submit a Pull Request** with your draft. Use `xxxx` in place of a number — an editor
+   will assign one prior to merging.
+4. **Engage with reviewers.** MIP Editors will help shepherd your proposal through the
+   process stages: *Proposed → Review → Accepted → Implemented*.
+
+See the
+[repository README](https://github.com/midnightntwrk/midnight-improvement-proposals#readme),
+[CONTRIBUTING](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/CONTRIBUTING.md),
+and [CODE_OF_CONDUCT](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/CODE_OF_CONDUCT.md)
+for full details.
+
+## License
+
+All contributions are licensed under the
+[Apache License 2.0](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/LICENSE).

--- a/mips/index.md
+++ b/mips/index.md
@@ -1,0 +1,22 @@
+---
+title: MIPs
+layout: default
+nav_order: 2
+permalink: /mips/
+---
+
+# Midnight Improvement Proposals (MIPs)
+
+Concrete, technically-precise proposals to change the Midnight ecosystem. See
+[MIP-0001]({{ "/mips/mip-0001-mip-process/" | relative_url }}) for the full process and
+[`mip-template.md`](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mips/mip-template.md)
+for the template.
+
+| # | Title | Status | Category |
+|---|-------|--------|----------|
+{% assign mips = site.pages | where_exp: "p", "p.path contains 'mips/mip-'" | sort: "path" -%}
+{% for p in mips -%}
+{% unless p.path contains 'template' -%}
+| {{ p.MIP }} | [{{ p.Title }}]({{ p.url | relative_url }}) | {{ p.Status }} | {{ p.Category }} |
+{% endunless -%}
+{% endfor %}

--- a/mips/mip-0001-mip-process.md
+++ b/mips/mip-0001-mip-process.md
@@ -1,5 +1,5 @@
 ---
-MIP: 1
+MIP: "0001"
 Title: Midnight Improvement Proposal Process
 Authors:
   - Bob Blessing-Hartley (bobblessinghartley)

--- a/mips/mip-0002-public-contract-log-emission.md
+++ b/mips/mip-0002-public-contract-log-emission.md
@@ -1,5 +1,5 @@
 ---
-MIP: 0002
+MIP: "0002"
 Title: Public Contract Log Emission for Compact Smart Contracts
 Authors:
   - Dominik Zajkowski (@dzajkowski)

--- a/mips/mip-0003-ecdsa-support.md
+++ b/mips/mip-0003-ecdsa-support.md
@@ -1,5 +1,5 @@
 ---
-MIP: 0003
+MIP: "0003"
 Title: ECDSA signature support
 Authors:
   - Andrzej Kopeć (kapke)

--- a/mips/mip-0004-fungible-token-standard-with-utxo.md
+++ b/mips/mip-0004-fungible-token-standard-with-utxo.md
@@ -1,5 +1,5 @@
 ---
-MIP: 0004
+MIP: "0004"
 Title: Fungible Token Standard with UTXO Conversion Extensions
 Authors:
   - Guido De Vita (dvgui)

--- a/mips/mip-0005-offer-files.md
+++ b/mips/mip-0005-offer-files.md
@@ -1,5 +1,5 @@
 ---
-MIP: 0005
+MIP: "0005"
 Title: Offer Files
 Authors: Andrew Fleming @andrew-fleming, Edward Alvarado <edward.alvarado@midnight.foundation>
 Status: Proposed

--- a/mips/mip-0006-p2p-atomic-swaps.md
+++ b/mips/mip-0006-p2p-atomic-swaps.md
@@ -1,5 +1,5 @@
 ---
-MIP: 0006
+MIP: "0006"
 Title: Peer-to-Peer Atomic Swaps
 Authors: Andrew Fleming @andrew-fleming, Edward Alvarado <edward.alvarado@midnight.foundation>
 Status: Proposed

--- a/mips/mip-0007-name-service-registry-and-resolver.md
+++ b/mips/mip-0007-name-service-registry-and-resolver.md
@@ -1,5 +1,5 @@
 ---
-MIP: 0007
+MIP: "0007"
 Title: Midnight Name Service — Canonical Registry and Resolver Standard
 Authors:
   - Midnames (midnames)

--- a/mips/mip-0008-caip-2-network-identifiers.md
+++ b/mips/mip-0008-caip-2-network-identifiers.md
@@ -1,5 +1,5 @@
 ---
-MIP: 0008
+MIP: "0008"
 Title: CAIP-2 Network Identifiers for Midnight
 Authors:
   - alba-press (alba-press)

--- a/mips/mip-0009-query-contract-state-rpc.md
+++ b/mips/mip-0009-query-contract-state-rpc.md
@@ -1,5 +1,5 @@
 ---
-MIP: 0009
+MIP: "0009"
 Title: Lazy Contract State Query RPC
 Authors: Rodrigo Quelhas @RomarQ
 Status: Proposed

--- a/mips/mip-0013-account-authorisation.md
+++ b/mips/mip-0013-account-authorisation.md
@@ -1,3 +1,18 @@
+---
+MIP: "0013"
+Title: Multi-key Account Authorisation for Custody Contracts
+Authors:
+  - Hector Bulgarini (hbulgarini)
+  - Nicolas Di Prima (NicolasDP)
+Status: Proposed
+Category: Standards
+Created: 2026-07-10
+License: Apache-2.0
+Requires: "MIP-0012: Contract Custody of Midnight-Native Assets"
+Replaces: none
+MPS: MPS-0018
+---
+
 <!--
  Copyright 2026 Midnight Foundation
 
@@ -14,20 +29,6 @@
  limitations under the License.
 -->
 
----
-MIP: "0013"
-Title: Multi-key Account Authorisation for Custody Contracts
-Authors:
-  - Hector Bulgarini (hbulgarini)
-  - Nicolas Di Prima (NicolasDP)
-Status: Proposed
-Category: Standards
-Created: 2026-07-10
-License: Apache-2.0
-Requires: MIP-0012: Contract Custody of Midnight-Native Assets
-Replaces: none
-MPS: MPS-0018
----
 
 ## Abstract
 

--- a/mps/index.md
+++ b/mps/index.md
@@ -1,0 +1,23 @@
+---
+title: MPS
+layout: default
+nav_order: 3
+permalink: /mps/
+---
+
+# Midnight Problem Statements (MPS)
+
+Solution-agnostic descriptions of friction, gaps, or opportunities in the ecosystem. MPS
+documents define *what* needs solving; MIPs propose *how*. See
+[MPS-0001]({{ "/mps/mps-0001-mps-process/" | relative_url }}) for the full process and
+[`mps-template.md`](https://github.com/midnightntwrk/midnight-improvement-proposals/blob/main/mps/mps-template.md)
+for the template.
+
+| # | Title | Status | Category |
+|---|-------|--------|----------|
+{% assign mpss = site.pages | where_exp: "p", "p.path contains 'mps/mps-'" | sort: "path" -%}
+{% for p in mpss -%}
+{% unless p.path contains 'template' -%}
+| {{ p.MPS }} | [{{ p.Title }}]({{ p.url | relative_url }}) | {{ p.Status }} | {{ p.Category }} |
+{% endunless -%}
+{% endfor %}

--- a/mps/mps-0002-developer-tooling.md
+++ b/mps/mps-0002-developer-tooling.md
@@ -1,5 +1,5 @@
 ---
-MPS: 0002  
+MPS: "0002"
 Title: Midnight Developer Tooling  
 Authors: Midnight Tooling Workforce  
 Status: Proposed  

--- a/mps/mps-0003-caip-support.md
+++ b/mps/mps-0003-caip-support.md
@@ -1,5 +1,5 @@
 ---
-MPS: 0003  
+MPS: "0003"
 Title: CAIP-2 Compliant Network Identifiers for Wallet Ecosystem Integration   
 Authors:
   - Bob Blessing-Hartley <bob@shielded.io>

--- a/mps/mps-0004-trusted-proof-serving.md
+++ b/mps/mps-0004-trusted-proof-serving.md
@@ -1,5 +1,5 @@
 ---
-MPS: 0004
+MPS: "0004"
 Title: Trustworthy Delegated Proof Generation for Privacy-Preserving Transactions
 Category: Ledger
 Status: Proposed

--- a/mps/mps-0005-events.md
+++ b/mps/mps-0005-events.md
@@ -1,6 +1,14 @@
 ---
-This is a legacy MPS that pre-dates the defined process, the components within may not conform to the MPS template.
+MPS: "0005"
+Title: Event Emission Support for Compact Smart Contracts (Phase 1)
+Status: Proposed
+Category: Standards
+Requires: none
+Replaces: none
+MIP: none
 ---
+
+> **Note:** This is a legacy MPS that pre-dates the defined process; the components within may not conform to the MPS template.
 
 # **Event Emission Support for Compact Smart Contracts- Phase 1**
 

--- a/mps/mps-0006-shielded-asset-custody.md
+++ b/mps/mps-0006-shielded-asset-custody.md
@@ -1,5 +1,5 @@
 ---
-MPS: 0006  
+MPS: "0006"
 Title: Institutional Custody for Native Shielded Assets (ZSwap)  
 Category: Core  
 Status: Proposed  

--- a/mps/mps-0007-node-event-visibility.md
+++ b/mps/mps-0007-node-event-visibility.md
@@ -1,5 +1,5 @@
 ---
-MPS: 0007  
+MPS: "0007"
 Title: Node-Side Visibility of Ledger Events  
 Authors: Giles Cope <giles.cope@shielded.io>  
 Status: Proposed  

--- a/mps/mps-0008-keccak-hashing.md
+++ b/mps/mps-0008-keccak-hashing.md
@@ -1,6 +1,14 @@
 ---
-This is a legacy MPS that pre-dates the defined process, the components within may not conform to the MPS template.
+MPS: "0008"
+Title: Native Keccak Hashing for Signature Verification
+Status: Proposed
+Category: Libraries and Tooling
+Requires: none
+Replaces: none
+MIP: none
 ---
+
+> **Note:** This is a legacy MPS that pre-dates the defined process; the components within may not conform to the MPS template.
 
 # Signature Verification - **Native Keccak Hashing**
 

--- a/mps/mps-0009-sig-rsa.md
+++ b/mps/mps-0009-sig-rsa.md
@@ -1,6 +1,14 @@
 ---
-This is a legacy MPS that pre-dates the defined process, the components within may not conform to the MPS template.
+MPS: "0009"
+Title: RSA 1024/2048 Signature Verification
+Status: Proposed
+Category: Libraries and Tooling
+Requires: none
+Replaces: none
+MIP: none
 ---
+
+> **Note:** This is a legacy MPS that pre-dates the defined process; the components within may not conform to the MPS template.
 
 # Signature Verification - **RSA 1024/2048**
 

--- a/mps/mps-0010-sig-verify-ecdsa.md
+++ b/mps/mps-0010-sig-verify-ecdsa.md
@@ -1,6 +1,14 @@
 ---
-This is a legacy MPS that pre-dates the defined process, the components within may not conform to the MPS template.
+MPS: "0010"
+Title: ECDSA/secp256k1 Signature Verification
+Status: Proposed
+Category: Libraries and Tooling
+Requires: none
+Replaces: none
+MIP: none
 ---
+
+> **Note:** This is a legacy MPS that pre-dates the defined process; the components within may not conform to the MPS template.
 
 # Signature Verification - **ECDSA/secp256k1**
 

--- a/mps/mps-0011-native-crypto-prims.md
+++ b/mps/mps-0011-native-crypto-prims.md
@@ -1,6 +1,14 @@
 ---
-This is a legacy MPS that pre-dates the defined process, the components within may not conform to the MPS template.
+MPS: "0011"
+Title: Native Cryptographic Primitives for Prime Stablecoin Integration
+Status: Proposed
+Category: Libraries and Tooling
+Requires: none
+Replaces: none
+MIP: none
 ---
+
+> **Note:** This is a legacy MPS that pre-dates the defined process; the components within may not conform to the MPS template.
 
 # Native Cryptographic Primitives for Prime Stablecoin Integration
 

--- a/mps/mps-0018-asset-custody-model.md
+++ b/mps/mps-0018-asset-custody-model.md
@@ -3,7 +3,7 @@ MPS: "0018"
 Title: Multi-key Account Custody for Midnight-Native Assets
 Authors: Hector Bulgarini (hbulgarini), Nicolas Di Prima (NicolasDP)
 Status: Proposed
-Category: Libraries and Tooling | Standards
+Category: Libraries and Tooling
 Created: 04-Jun-2026
 Requires: none
 Replaces: none

--- a/mps/mps-0027-domain-separation.md
+++ b/mps/mps-0027-domain-separation.md
@@ -5,7 +5,7 @@ Authors:
 - Hector Bulgarini (hbulgarini)
 - Nicolas Di Prima (NicolasDP)
 Status: Proposed
-Category: Libraries and Tooling | Standards
+Category: Libraries and Tooling
 Created: 23-Jun-2026
 Requires: none
 Replaces: none

--- a/mps/mps-0032-storage-management.md
+++ b/mps/mps-0032-storage-management.md
@@ -1,3 +1,15 @@
+---
+MPS: "0032"
+Title: History Management for Midnight
+Authors: Dominik Zajkowski @dzajkowski
+Status: Proposed
+Category: Core
+Created: 14-MAY-2026
+Requires: none
+Replaces: none
+MIP: none
+---
+
 <!--
  Copyright 2026 Midnight Foundation
  
@@ -14,18 +26,6 @@
  limitations under the License.
 -->
 
----
-MPS: "0032"  
-Title: History Management for Midnight  
-Authors: Dominik Zajkowski @dzajkowski  
-Status: Proposed  
-Category: Core  
-Created: 14-MAY-2026  
-Requires: none  
-Replaces: none  
-MIP: none
-
----
 
 ## Abstract
 


### PR DESCRIPTION
## Summary

Publishes this repository as a browsable static site on GitHub Pages, closing #28.

Uses **Jekyll** — the de-facto standard for improvement-proposal repos (EIPs, BIPs, and the Cardano CIPs example cited in the issue all use it) — with the **just-the-docs** theme for sidebar navigation and built-in full-text search. Proposal Markdown is rendered **in place**; the repo structure is unchanged (no moving files into `_mips/` collection folders), so the repo remains the canonical source.

Once merged, enable Pages via **Settings → Pages → Source: GitHub Actions**. The site publishes at `https://midnightntwrk.github.io/midnight-improvement-proposals/`.

## What's included

- **`_config.yml`** — theme, `baseurl`, path-based layout defaults, and `jekyll-relative-links` so in-document `.md` links resolve to real page URLs.
- **`Gemfile`** — pins `jekyll`, `just-the-docs`, and `jekyll-relative-links`.
- **`_layouts/proposal.html`** — renders a metadata header (number, Status, Category, Authors, Created, Requires/Replaces) for each proposal. Handles both author formats present in the corpus (YAML list *and* plain string).
- **`index.md`** — landing page.
- **`mips/index.md`, `mps/index.md`** — index tables auto-generated from the proposal front matter (#, Title, Status, Category), sorted by number.
- **`.github/workflows/pages.yml`** — official Jekyll-via-Actions build + deploy on push to `main`.
- **`_sass/custom/custom.scss`** — small theme override so the wrapping sidebar title isn't clipped.
- **`.gitignore`** — ignores build artifacts (`_site/`, `vendor/`, caches).

## Content fixes needed to render

Building the site surfaced front matter that Jekyll couldn't use. Minimal, targeted fixes:

- **Front matter added/relocated (7 proposals):** `mip-0013` and `mps-0032` had valid front matter placed *after* the license comment (Jekyll requires it at the top) — relocated, and quoted a `Requires:` value with a colon. Five legacy MPSs (`mps-0005/0008/0009/0010/0011`) had a plain-text note instead of key/value front matter — replaced with proper front matter, preserving the original note as a body blockquote.
- **Number normalization (14 files):** unquoted values like `MIP: 0005` were parsed as integers, dropping the leading zeros (they displayed as `1`–`7`). Quoted them as 4-digit strings (`mip-0001`–`0009`, `mps-0002/0003/0004/0006/0007`).
- **Category rendering (2 files):** `mps-0018` and `mps-0027` had a `|` in the Category value, which spawned a stray column in the index table — removed the pipe.

Line endings were preserved throughout (`mip-0008` is CRLF).

## Preview locally

```bash
bundle install
bundle exec jekyll serve --baseurl "/midnight-improvement-proposals"
# → http://localhost:4000/midnight-improvement-proposals/
```

## Notes / possible follow-ups

- **`deployments/`** records have no front matter and are excluded from the site for now (they'd otherwise ship as raw Markdown). Adding front matter would let them render.
- **Templates** are excluded from the site and linked to GitHub instead.
- For the five legacy MPSs, `Authors`/`Created` were left out (unknown in source) and **Category values are best-guess** — worth a maintainer sanity-check.

Closes #28
