### PR TITLE
MIP-xxxx: Message Signing

### DIFF
--- a/mips/mip-xxxx.md
+++ b/mips/mip-xxxx.md
@@ -1,0 +1,298 @@
+---
+MIP: X
+Title: Midnight Message Signing
+Authors:
+  - Andrzej Kopeć (kapke)
+Status: Draft
+Category: Standards
+Created: 2026-09-08
+Requires: "MIP-0003: ECDSA signature support"
+Replaces: none
+MPS: none
+License: Apache-2.0
+---
+
+<!--
+ Copyright Midnight Foundation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+## Abstract
+
+A DApp can ask the user's wallet to sign arbitrary data, by calling `signData` on the [DApp Connector API](https://github.com/midnightntwrk/midnight-dapp-connector-api/). The wallet signs with the user's unshielded key and returns the signature. This MIP specifies that procedure end to end: which bytes the wallet signs, and the algorithm anyone follows to check the result afterwards. Checking a signature needs no wallet, no connector and no Midnight-specific software.
+
+The mechanism is already deployed; what is missing is a findable, complete, normative description. This MIP lifts the procedure out of the [DApp Connector API specification](https://github.com/midnightntwrk/midnight-dapp-connector-api/blob/main/SPECIFICATION.md) and settles the points that specification leaves silent, then pins the result with machine-checkable test vectors. Conformance is a break with what ships: no wallet today returns a signature this document accepts. Both schemes the connector names, `schnorr_bip340` and `ecdsa_secp256k1_sha256`, are specified normatively.
+
+## Motivation
+
+The procedure's only normative statement is a single sentence in the Signing section of the DApp Connector API specification, backed by doc comments on the API's TypeScript types. Neither is where an implementer looks for a signing algorithm. No other document describes the message construction: MIP-0003 extends the same `Signature` response type with the `scheme` discriminator but says nothing about what is signed, and the Wallet specification is silent.
+
+Multiple known implementations already disagree, and several reached the same misreading independently, in codebases that share no code. The specification, not the code, is the thing to correct. An implementation that never finds the Signing sentence omits the prefix altogether, losing the domain separation it provides. Elsewhere the text does not settle what the length counts, what `data` returns, how malformed input is handled, which value the signature binds, or how the wire fields are encoded. This MIP is meant to be both findable and complete.
+
+## Specification
+
+The key words MUST, MUST NOT, SHOULD and MAY are to be interpreted as described in BCP 14 (RFC 2119 and RFC 8174) when, and only when, they appear in all capitals, as shown here.
+
+This MIP profiles the DApp Connector API's existing types. It changes one of them: `scheme` is optional on the connector's `Signature` and defaults there to `schnorr_bip340`; here it is required. [MIP-0003](./mip-0003-ecdsa-support.md#dapp-connector-api) foresaw that change when it introduced the field. Until the connector API's next major version ships — the one [§8](#8-versioning) calls for — this document governs where the two disagree. A few rules presuppose the connector: the error shape of §2, and the JavaScript-specific typing rules of §2 and §7.
+
+```ts
+signData(data: string, options: SignDataOptions): Promise<Signature>;
+
+type SignDataOptions = { encoding: 'hex' | 'base64' | 'text'; keyType: 'unshielded' };
+
+type Signature = {
+  scheme: 'schnorr_bip340' | 'ecdsa_secp256k1_sha256';
+  data: string;
+  signature: string;
+  verifyingKey: string;
+};
+```
+
+### 1. Message construction
+
+The signed message `M` is the byte concatenation
+
+```
+M = utf8("midnight_signed_message:")  ‖  dec(L)  ‖  utf8(":")  ‖  P
+```
+
+where `P` is the decoded payload (§2). This document calls `midnight_signed_message:` the *prefix literal*, and everything in `M` ahead of `P` the *prefix*.
+
+`M` is a function of `P` alone: no `encoding`, no `keyType`, no network identifier, timestamp or nonce enters it. Two calls whose payloads decode to the same `P` therefore produce the same `M`, and their signatures are interchangeable. A DApp relying on a signature for authentication SHOULD place both a nonce and its own identity in `P`: without the nonce an old signature replays, and without the identity one DApp's challenge serves at any other.
+
+- The prefix literal is the 24-byte ASCII string `midnight_signed_message:`, in hexadecimal `6d69646e696768745f7369676e65645f6d6573736167653a`.
+- `L` MUST count bytes of the **decoded** payload, never characters of the input string.
+- `dec(L)` MUST be the shortest ASCII decimal representation of `L`: digits U+0030–U+0039 only, no leading zeros, `0` when `L` is zero, no sign, no grouping separators.
+- This MIP imposes no upper bound on `L`. A *producer* — an implementation of `signData` — MAY refuse an oversized payload with `InvalidRequest`; a producer that accepts one MUST use its full byte length.
+
+### 2. Payload derivation
+
+`P` is derived from `data` according to `options.encoding`.
+
+- `options` MUST be an object and `data` MUST be a string.
+- `options.encoding` MUST be present and exactly one of `'hex'`, `'base64'` and `'text'`; a missing or unrecognised `encoding` MUST be rejected rather than defaulted or inferred.
+- `options.keyType` MUST be present and MUST be `'unshielded'`; any other value, and its absence, MUST be rejected.
+- Validation MUST complete before any signing occurs and before any approval prompt the producer shows.
+- On failure the producer MUST throw an `APIError` per the connector specification's Errors section, with `code: 'InvalidRequest'`, and MUST NOT return a `Signature`.
+- A producer MUST NOT fall back to another encoding when the declared one fails to parse: there is no sniffing and no retry. A rejected input MUST NOT be repaired and then accepted: no truncating, padding, stripping or substituting a replacement character.
+- The empty string MUST be accepted under all three encodings, yielding `L = 0`.
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col"><code>encoding</code></th>
+      <th scope="col"><code>P</code></th>
+      <th scope="col">Accepted</th>
+      <th scope="col">Rejected</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td valign="top"><code>hex</code></td>
+      <td valign="top">the decoded bytes</td>
+      <td valign="top">
+        <ul>
+          <li>hexadecimal digits in either case — <code>^[0-9a-fA-F]*$</code></li>
+          <li>even length</li>
+        </ul>
+      </td>
+      <td valign="top">
+        <ul>
+          <li>odd length</li>
+          <li>a <code>0x</code> or <code>0X</code> prefix</li>
+          <li>whitespace and any other non-hexadecimal character</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td valign="top"><code>base64</code></td>
+      <td valign="top">the decoded bytes</td>
+      <td valign="top">canonical base64 under RFC 4648</td>
+      <td valign="top">everything else — unpadded, whitespace, the URL-safe alphabet, non-zero trailing bits — much of which a permissive decoder accepts</td>
+    </tr>
+    <tr>
+      <td valign="top"><code>text</code></td>
+      <td valign="top">the UTF-8 encoding of the string as given</td>
+      <td valign="top">any string encodable as well-formed UTF-8</td>
+      <td valign="top">a string containing an unpaired surrogate, which RFC 3629 forbids encoding</td>
+    </tr>
+  </tbody>
+</table>
+
+The `reason` accompanying an error is human-readable and unspecified; a DApp MUST NOT branch on it.
+
+### 3. Digest and signature schemes
+
+Let `h = SHA-256(M)` — a single untagged application over the whole of `M`, prefix included. The signature MUST bind `h` under both schemes, and MUST NOT bind `SHA-256(P)`, a tagged hash of `M`, or `SHA-256(h)`.
+
+- `schnorr_bip340` — sign and verify with `h`, the 32 bytes, as BIP-340's message input.
+- `ecdsa_secp256k1_sha256` — sign and verify `h` as the ECDSA digest, i.e. ECDSA-with-SHA-256 over `M`.
+
+The key a wallet signs with MUST be the key whose address it reports through the connector's unshielded-address API, `getUnshieldedAddress`. Which address derivation applies follows from the `scheme` the returned `Signature` declares; both derivations are given in [MIP-0003](./mip-0003-ecdsa-support.md#address-generation). `getUnshieldedAddress` takes no scheme argument and is answered before `signData`, so a wallet holding an unshielded key under each scheme MUST pick one of those keys for the lifetime of a `ConnectedAPI` — the object the connector's `connect` resolves to — and report that key's address.
+
+Signatures under either scheme MAY be randomised, so two calls signing the same `M` may return different signatures. Nonce derivation belongs to the scheme, not to this procedure, and this document fixes none for either. A verifier therefore:
+
+- MUST NOT treat two differing signatures over the same `M` as an error;
+- MUST NOT require any particular nonce derivation, which a signature does not expose for checking.
+
+### 4. The `scheme` discriminator
+
+Producers MUST emit `scheme` on every `Signature`, spelled exactly `'schnorr_bip340'` or `'ecdsa_secp256k1_sha256'`, and MUST NOT emit any other discriminator field. A verifier resolves it as step 1 of [§7](#7-verification) prescribes. Verifiers MUST ignore fields they do not recognise and MUST NOT read any field other than `scheme` as a discriminator.
+
+The scheme is not negotiated: it follows from the key material the producer holds. The connector specification's Signing section already requires a DApp to handle both.
+
+### 5. Wire encoding of `Signature`
+
+- `data`, `signature` and `verifyingKey` MUST each be bare lowercase hexadecimal (`^[0-9a-f]*$`) of even length, with no `0x` prefix, no separators, no whitespace and no version or tag bytes. Producers MUST emit lowercase; verifiers MUST reject any value not in that canonical form.
+- `data` MUST be the hexadecimal encoding of the whole of `M`, prefix included.
+- `signature` MUST be exactly 128 hexadecimal characters under both schemes. Its two 32-byte halves are `r ‖ s`, both big-endian, for `ecdsa_secp256k1_sha256`, and BIP-340's `bytes(R) ‖ bytes(s)` for `schnorr_bip340`.
+- `verifyingKey` MUST be exactly 64 hexadecimal characters for `schnorr_bip340`, a 32-byte BIP-340 x-only key, and exactly 66 for `ecdsa_secp256k1_sha256`, a 33-byte SEC1 compressed point leading with `02` or `03`. An uncompressed SEC1 key MUST be rejected.
+- For `ecdsa_secp256k1_sha256` a producer MUST emit `s <= (n-1)/2`, where `n` is the secp256k1 group order; a signing routine that yields a high `s` MUST have it replaced by `n - s` before the `Signature` is returned. `schnorr_bip340` carries no such bound.
+
+### 6. Worked examples (non-normative)
+
+The declared encoding, not the string, determines the bytes:
+
+| `encoding` | `data`, `L` | `M` (hex) |
+|---|---|---|
+| `text` | `decade`, 6 | `6d69646e696768745f7369676e65645f6d6573736167653a363a646563616465` |
+| `hex` | `decade`, 3 | `6d69646e696768745f7369676e65645f6d6573736167653a333adecade` |
+| `base64` | `3sre`, 3 | `6d69646e696768745f7369676e65645f6d6573736167653a333adecade` |
+
+The second and third rows are the same message, as §1 requires, so their signatures are interchangeable; `h = SHA-256(M)` for both is `3e1a914a91ed897e6e20423b3761a6026a9cdd039867f74e509d4f8af885f0e4`. The vector `schnorr-hex-decade` carries the `Signature` for the second row, and verifies under [§7](#7-verification) against the three bytes `decade`.
+
+### 7. Verification
+
+Verification takes the `Signature` object of the typings above together with `P_exp`, the payload bytes the verifier asked to be signed. A DApp derives `P_exp` by applying §2 to the exact `data` and `encoding` it passed to `signData`. The `Signature` is untrusted on arrival, so `P_exp` MUST NOT be recovered from it or informed by any of its fields. A verifier acting for another party MUST receive `P_exp` from the party that made the request, over a channel independent of the `Signature`. That party may send the `data` and `encoding` instead, and the verifier derives `P_exp` per §2.
+
+Verification establishes that the holder of `verifyingKey` signed `M`, not who that holder is: a wallet that ignores §3's key-binding rule can sign under a key it generated for the purpose and still pass every step below. A verifier that attributes any meaning to the signature MUST therefore also check `verifyingKey` against a key or address it obtained independently of the `Signature`, deriving that address per [MIP-0003](./mip-0003-ecdsa-support.md#address-generation) for the resolved scheme.
+
+Throughout the steps below, a verifier:
+
+- MUST reach a verdict on every input. An untrusted `Signature` crosses an in-page boundary, so its property accessors may themselves throw; such a throw is a rejection, and MUST NOT escape as though verification had not concluded.
+- MUST read each field of the `Signature` once, and carry the value it first read through every later step.
+- SHOULD bound the length of `data` it will decode, rejecting an oversized value before step 3. That bound is a local resource guard rather than a conformance rule: §1 fixes no upper bound on `L`, so two verifiers may draw it in different places and a bounded verifier may reject an otherwise valid signature.
+- MUST NOT, on a step 9 failure, retry with another message construction — not the bare payload, not `SHA-256(P)`, not `M` unhashed.
+
+1. Reject unless the `Signature` is a non-null object that is not an array. Then read `scheme` and reject unless it is exactly one of the two literals; an absent or `null` `scheme` is rejected exactly as an unrecognised one.
+2. Reject any of `data`, `signature` and `verifyingKey` that is absent, is not a string, or does not match the §5 wire form for the resolved scheme.
+3. Let `M := hexDecode(data)`.
+4. Reject unless `M` begins with the 24-byte prefix literal.
+5. Read the maximal run of ASCII digits at offset 24. Reject unless it is non-empty, has no leading zero unless it is the single digit `0`, and is immediately followed by the byte `0x3a` (`:`). Let `L` be its value.
+6. Let `P := M[k..]`, where `k` is the offset just past that colon; reject unless `len(P) == L`.
+7. Reject unless `P` equals `P_exp` byte for byte.
+8. Let `h := SHA-256(M)`.
+9. Verify per scheme: `schnorr_bip340` — BIP-340 verify with message `h` and the x-only key; `ecdsa_secp256k1_sha256` — ECDSA verify with `h` as the digest and the compressed key, additionally rejecting `s > (n-1)/2`.
+10. Accept only if every step passed.
+
+### 8. Versioning
+
+Requiring `scheme` is a breaking change to the connector's `Signature` type, so a new major version of the DApp Connector API will be released to signal conformance with this document. Versioning of this procedure belongs to that API. A later MIP that supplements the procedure — adding a third signature scheme, for instance — may in turn require a new version of that API.
+
+## Rationale
+
+Many choices here are settled in advance by the two schemes this document must support and by the precedent of EIP-191.
+
+CIP-8, the Cardano analog, wraps the payload in COSE_Sign1 and CBOR. Midnight's mechanism already ships as a plain byte concatenation. Adopting a serialization format now would invalidate every deployed signature and add a parser to every verifier, buying no property this document needs.
+
+The prefix is there for the domain separation Security Considerations sets out; the decoded byte length makes `M` self-describing, so a message truncated or extended after construction fails step 6 of [§7](#7-verification) instead of verifying over a shorter payload.
+
+`data` carries the whole of `M` so that `M` can be reconstructed from the `Signature` object alone; echoing the caller's input would force every verifier to know the original `encoding` and rebuild `M` from it.
+
+## Path to Active
+
+For a Standards MIP, Active means that deployed wallets and DApps run the procedure specified here and that the connector specification points to this document for it. `signData` is an off-chain wallet operation, so no network upgrade is required; the path runs through the connector specification's next major revision, corrections in shipping producers, and independent conformance against the vectors.
+
+### Acceptance Criteria
+
+- A verifier written by an implementer who is not an author of this MIP accepts every valid vector and rejects every `kind: "verification"` vector.
+- The DApp Connector API specification's Signing section cites this MIP as the normative description of the procedure, and a released major version of `@midnightntwrk/dapp-connector-api` carries `scheme` as a required field of `Signature`.
+- At least two `signData` producers, independent of each other and of this MIP's authors, meet the producer rules under Testing.
+
+### Implementation Plan
+
+Adoption is documentary and per-implementation, and no step below depends on the others:
+
+- Cite this MIP from the connector specification, make `scheme` required in its `Signature` type, delete the default-to-`schnorr_bip340` rule from the Signing section and from the `Signature` doc comment, and publish that as a new major version.
+- Change producers to return `hex(M)` in `data` and to emit `scheme`.
+- Tighten payload validation wherever malformed input is currently repaired.
+- Apply the prefix wherever it is currently omitted.
+- Correct the description of both signature halves as "the scalars `r` and `s`", wrong for `schnorr_bip340`, in all three places it appears: `SPECIFICATION.md`, the `Signature` doc comment in `src/api.ts`, and [MIP-0003's transaction-format section](./mip-0003-ecdsa-support.md#transaction-format-and-signature-verification).
+
+## Backwards Compatibility Assessment
+
+`signData` is an off-chain wallet operation: this MIP requires no hard fork, no ledger change and no consensus change. What changes is what counts as a conformant `Signature`, and no deployed producer emits one: none returns `hex(M)` in `data`, and `scheme` has so far shipped only in a prerelease of the API. A verifier following [§7](#7-verification) therefore rejects every signature a shipping wallet returns today. The type itself changes too: `scheme` is required here and optional in the connector's `Signature`, which is why §8 calls for a major version. This MIP deliberately defines no transition period and no dual acceptance: a verifier permitted to treat a structurally invalid `data` as a raw echo reopens the ambiguity being closed.
+
+## Security Considerations
+
+**The prefix is a security control, not a style choice.** It exists so that a value signed through `signData` cannot also be a well-formed Midnight transaction. Under `ecdsa_secp256k1_sha256` that holds as long as no transaction's signing message begins with the 24-byte prefix literal. Under `schnorr_bip340` the signature binds `h` rather than `M`, so it holds as long as no transaction's BIP-340 message equals `SHA-256` of a prefixed message. This MIP claims no proof of domain separation; an implementation that omits the prefix removes the control.
+
+**The producer controls the bytes that get signed.** A malicious or buggy producer can return a valid signature over a message the DApp never asked for, and silently repairing malformed input has the same effect. Step 7 of [§7](#7-verification) catches this, and it is not optional. A verifier that holds no `P_exp` cannot verify under this MIP at all, and MUST NOT report the weaker fact — that some message was signed — as verification. Because a signature cannot be withdrawn once made, [§2](#2-payload-derivation) forbids repair before anything is signed rather than leaving it to a later check.
+
+**ECDSA signatures are malleable.** Without the low-`s` bound, a third party can derive a second valid signature over the same `M` from an existing one, which is why [§5](#5-wire-encoding-of-signature) requires the bound of producers and [§7](#7-verification) step 9 of verifiers. No Midnight verifier enforces it today, so a verifier cannot assume the signatures reaching it already meet the bound.
+
+**The signed message binds no context.** `M` is a function of `P` alone ([§1](#1-message-construction)): it carries no nonce, no challenge, no timestamp, no network identifier and no DApp identity. A DApp that needs a signature to bind any of those puts them in `P` itself; [§1](#1-message-construction) recommends a nonce and the DApp's own identity for authentication. That identity closes cross-DApp reuse — a signature made for one DApp presented at another — but not relay: a hostile site can take the challenge a genuine DApp issued, identity and all, present it to the user as its own, and hand the resulting signature back to that DApp. This document takes no position beyond that.
+
+## Implementation
+
+The components that change are the DApp Connector API specification and wallets implementing `signData` — chiefly their payload validation and the `data` they return.
+
+## Testing
+
+The vectors are at [`./mip-xxxx/vectors.json`](./mip-xxxx/vectors.json). They cover the bytes; §2's rules about the shape of `data` and `options` cannot be written down in the file, and a harness has to check those by other means. No valid vector's `input` carries `keyType`, by convention rather than omission: a producer harness replaying one MUST supply `'unshielded'`.
+
+Two of the file's fields carry rules rather than data. `schemaVersion` is an integer, and a harness reading the file MUST reject a value it does not recognise. Every vector with `valid: false` carries a `kind` naming its class: `payload` for a §2 rejection a producer must make, `verification` for a §7 rejection a verifier must make. A harness MUST switch on `kind` rather than infer the class from which fields are present.
+
+A conformant producer MUST:
+
+- reproduce, from each valid vector's `input`, the four values that vector pins: the payload, its length, the message and the digest;
+- reproduce a valid vector's `signature.signature` byte for byte when either determinism condition holds:
+  - its `signatureDeterminism` is `rfc6979` and the producer does derive its nonces that way, or
+  - its `signatureDeterminism` is `bip340-aux-fixed` and the producer accepts external auxiliary randomness (`auxRandHex`);
+- return, for every valid vector, a `Signature` that verifies under §7 against the vector's `payloadHex`;
+- reject every `kind: "payload"` vector's `input` with `InvalidRequest`.
+
+For a producer meeting neither determinism condition, that verification is the only check on the signature it returns.
+
+A conformant verifier MUST:
+
+- accept every valid vector's `signature`, with that vector's `payloadHex` as `P_exp`;
+- reject every `kind: "verification"` vector's `signature` against its `payloadHex`.
+
+A verifier never sees an `input`, an `encoding` or an error code.
+
+`expectedFailureStep` names the §7 step at which a verifier executing the algorithm in order first fails, and each such vector fails at exactly that step and passes every step before it. That field is diagnostic: rejection is the pass criterion, and a verifier that returns only accept or reject MAY ignore it.
+
+## References
+
+- [DApp Connector API specification](https://github.com/midnightntwrk/midnight-dapp-connector-api/blob/main/SPECIFICATION.md) — the Signing section this MIP lifts and completes, and [the API's types](https://github.com/midnightntwrk/midnight-dapp-connector-api/blob/main/src/api.ts)
+- [MIP-0003: ECDSA signature support](./mip-0003-ecdsa-support.md) — the ECDSA scheme, its key and address derivation, and its ledger-level low-`s` rule
+- [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) — Schnorr signatures for secp256k1
+- [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648) — base64 encoding (Section 4) and canonical encoding (Section 3.5); [RFC 3629](https://www.rfc-editor.org/rfc/rfc3629) — UTF-8; [RFC 6979](https://www.rfc-editor.org/rfc/rfc6979) — deterministic ECDSA nonces, and its Abstract's guarantee that they are verifiable by unmodified verifiers
+- [FIPS 180-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf) Section 6.2 — SHA-256
+- [SEC 1 v2.0](https://www.secg.org/sec1-v2.pdf) Section 2.3.3 — compressed elliptic-curve point encoding; [SEC 2 v2.0](https://www.secg.org/sec2-v2.pdf) Section 2.4.1 — secp256k1's parameters, including the group order `n`
+- [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174) — the requirement keywords
+- [BIP-146](https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki) — signature encoding malleability; the low-`s` bound, proposed as consensus and left unactivated
+- [EIP-2](https://eips.ethereum.org/EIPS/eip-2) — the low-`s` bound made binding for Ethereum transaction signatures, and explicitly not for signature recovery
+- [EIP-191](https://eips.ethereum.org/EIPS/eip-191) — Ethereum's signed-data prefix, the closest analogue to §1's message construction
+- [CIP-8](https://cips.cardano.org/cip/CIP-8) — the Cardano message-signing standard this document parallels
+
+## Acknowledgements
+
+Special thanks to the Wallet Working Group for reporting the issues and highlighting the need for this MIP.
+
+## Copyright Waiver
+
+All contributions (code and text) submitted in this MIP must be licensed under the Apache License, Version 2.0.
+Submission requires agreement to the Midnight Foundation Contributor License Agreement [Link to CLA], which includes the assignment of copyright for your contributions to the Foundation.

--- a/mips/mip-xxxx/vectors.json
+++ b/mips/mip-xxxx/vectors.json
@@ -1,0 +1,1278 @@
+{
+  "schemaVersion": 1,
+  "warning": "The signing keys in this file are test keys with publicly known values. They exist so that every signature here can be reproduced. Never use them on any network. Each named key carries a separate scalar per scheme, and no scalar signs under both: a secret key used for Schnorr and for ECDSA alike can be recovered outright from a nonce reused across the two, so the schemes are separated here as they are separated at key derivation. Do not collapse the pair back into one scalar when adapting these vectors. No valid vector names a keyType, and that is the convention rather than an omission: absent means unshielded, which is the only key type that signs messages, so a vector for the absent case would be indistinguishable from every other vector here. The one vector that names the field names the rejected value. Read an input without a keyType as asking for an unshielded key, not as leaving the key type open. Two vectors carry an unpaired surrogate escape in input.data on purpose, to check that an implementation rejects a lone surrogate instead of substituting U+FFFD; the escape is the only way to write one, a lone surrogate having no UTF-8 form. RFC 8259 section 8.2 permits it as non-interoperable, not ungrammatical: Node and Python parse this file, jq does not. Use a parser that accepts it rather than skipping the two vectors.",
+  "keys": {
+    "key-a": {
+      "schnorrSigningKeyHex": "0707070707070707070707070707070707070707070707070707070707070707",
+      "schnorrVerifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f",
+      "ecdsaSigningKeyHex": "2121212121212121212121212121212121212121212121212121212121212121",
+      "ecdsaVerifyingKey": "028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7"
+    },
+    "key-b": {
+      "schnorrSigningKeyHex": "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef",
+      "schnorrVerifyingKey": "dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659",
+      "ecdsaSigningKeyHex": "2222222222222222222222222222222222222222222222222222222222222222",
+      "ecdsaVerifyingKey": "02466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27"
+    },
+    "key-c": {
+      "schnorrSigningKeyHex": "1313131313131313131313131313131313131313131313131313131313131313",
+      "schnorrVerifyingKey": "1d16453b3ab3132acb0a5bc16cc49690d819a585267a15cd5a064e2a0ad40599",
+      "ecdsaSigningKeyHex": "2323232323232323232323232323232323232323232323232323232323232323",
+      "ecdsaVerifyingKey": "03e11f40af6b41f494bfbc27c47a178ce572e8b8ca687cc67e1298514861ac5e48"
+    }
+  },
+  "vectors": [
+    {
+      "name": "schnorr-empty-text",
+      "description": "Empty text payload; the message is the prefix, a zero length and a colon.",
+      "input": {
+        "encoding": "text",
+        "data": ""
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "",
+      "payloadLength": 0,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a303a",
+      "messageDigestHex": "95110fab6d608d99410204176ebaeab903c027af107fad1738a8d580608bfe8d",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "08254c19e1a9d0d3e9de35894c8c7839f9a97eb2b4f19198b79660f71d7facdd",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a303a",
+        "signature": "6ad396c21a25cbe4332b7e04c8f568a8886782d86e431080c568344f03880709e246ea65e95f6b22dc106ccbb30cf53e16e2b867a8cbe5ad47ee90469fbed541",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-empty-hex",
+      "description": "Empty hex payload; the same message as the empty text payload.",
+      "input": {
+        "encoding": "hex",
+        "data": ""
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "",
+      "payloadLength": 0,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a303a",
+      "messageDigestHex": "95110fab6d608d99410204176ebaeab903c027af107fad1738a8d580608bfe8d",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "d236a6dbde598aaeb92cab0eac428ce94296128cd2e01b6ee5335282685eee01",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a303a",
+        "signature": "38f08aff0bf9d81854bef6360d497ae1b042bad5e0074e207d42444df1d16955d990408b4b42483cfd66700b5d3b7af6687c8c48505e905603cbc4c64de090ed",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-empty-base64",
+      "description": "Empty base64 payload; the same message again.",
+      "input": {
+        "encoding": "base64",
+        "data": ""
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "",
+      "payloadLength": 0,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a303a",
+      "messageDigestHex": "95110fab6d608d99410204176ebaeab903c027af107fad1738a8d580608bfe8d",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "00f217160751a8d1f421162727b929e7f507916a76136a16285cbac2510e33f4",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a303a",
+        "signature": "92329038f641e4eaf4b1d4226b7ba260d032e183f58ec7f54b7bb0dcc949b2f779a0609f3cff5ae6b703fa7e5b8f5bb12c22f59dd1635240dcfaf3a56bc417f0",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "ecdsa-empty-text",
+      "description": "The empty payload under ECDSA; same message and digest, different signature.",
+      "input": {
+        "encoding": "text",
+        "data": ""
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "ecdsa_secp256k1_sha256",
+      "payloadHex": "",
+      "payloadLength": 0,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a303a",
+      "messageDigestHex": "95110fab6d608d99410204176ebaeab903c027af107fad1738a8d580608bfe8d",
+      "signatureDeterminism": "rfc6979",
+      "auxRandHex": null,
+      "signature": {
+        "scheme": "ecdsa_secp256k1_sha256",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a303a",
+        "signature": "2285bf17f612f6fca1e04196ae848142cb33e7b786c9c23da23e9c8fdebafdeb7e07030a6d42ccc110fa18950a011015d0ca40a913743d62ca41496e9ff3df2c",
+        "verifyingKey": "028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7"
+      }
+    },
+    {
+      "name": "schnorr-hex-decade",
+      "description": "The three bytes de ca de, requested as hex; the length is 3, not 6.",
+      "input": {
+        "encoding": "hex",
+        "data": "decade"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "decade",
+      "payloadLength": 3,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+      "messageDigestHex": "3e1a914a91ed897e6e20423b3761a6026a9cdd039867f74e509d4f8af885f0e4",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "fe85f728dc5c81dc07400700ca9d43323a9858e1447b79b1b0e3db6b7c5bda2c",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "1b05daaa52499a57007c9d30d40e09ba3bf9ff303595af92953cfbc80c7d8338fc657f7f4d8ada49f3559ab9003806c8d7889c7e4f57618fb3b97344472fb962",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-text-decade",
+      "description": "The same six characters as text: six ASCII bytes, a different message entirely.",
+      "input": {
+        "encoding": "text",
+        "data": "decade"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "646563616465",
+      "payloadLength": 6,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a363a646563616465",
+      "messageDigestHex": "691d8be9cb28a83b8a95a46417cd51427a5a2fc1aa7b4a4420848b984794ebb5",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "866ac63dfa79424bba6baa683ad3839b3123cea40888780744cc4b6d6499ad37",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a363a646563616465",
+        "signature": "576ddd7704f6438ca27f3f21b348ce419e98dc8620870caac3b81c5accfd2913afaef5192ad5016afab587e055fc8ba2c5156d19f0ab79e7b07d094e440c2556",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-hex-decade-uppercase",
+      "description": "Uppercase hex decodes to the same bytes, so it produces the same message.",
+      "input": {
+        "encoding": "hex",
+        "data": "DECADE"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "decade",
+      "payloadLength": 3,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+      "messageDigestHex": "3e1a914a91ed897e6e20423b3761a6026a9cdd039867f74e509d4f8af885f0e4",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "c34e8e31118c7b95fb4f1159401c5badd1c668f93c59582a040ec9b1dbb80a54",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "77bdb8b0acf1f6dde87026cf2fdeffca83441ffa3d23bf28682039183f9d406a634954c7f5ee61bf4f148175c02be64ecd930e2769280831e62b7491e62482f5",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-base64-decade",
+      "description": "Base64 of those same three bytes; again the same message, so the signatures are interchangeable.",
+      "input": {
+        "encoding": "base64",
+        "data": "3sre"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "decade",
+      "payloadLength": 3,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+      "messageDigestHex": "3e1a914a91ed897e6e20423b3761a6026a9cdd039867f74e509d4f8af885f0e4",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "a592ea67658a01db975a684ba52eceab2d09a0a9a09e0b8a658f71636eb41c0c",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "0b18475857291513fccf4f75d4f1d04e4221e71c387e5a993edb8087350035908ac44d203a91ec2986c89d1f4b2554a6a9751bc91f338a09d13c692c6dde2422",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-hex-decade-second-key",
+      "description": "The same message signed by a second key, so a verifier cannot ignore the verifying key.",
+      "input": {
+        "encoding": "hex",
+        "data": "decade"
+      },
+      "valid": true,
+      "key": "key-b",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "decade",
+      "payloadLength": 3,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+      "messageDigestHex": "3e1a914a91ed897e6e20423b3761a6026a9cdd039867f74e509d4f8af885f0e4",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "5e20b5753a61079edd0c746031d854160150f0e4450d40b6696021d6b14fbb2b",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "f5741519a7b5ce7b8e36ecc2c870d152ec7acfb42f40a3940ca602403bc40332bddded68613fe188db91841bdd77e5323539cf06d82fc3e373bbe0828c4fb609",
+        "verifyingKey": "dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659"
+      }
+    },
+    {
+      "name": "ecdsa-hex-decade",
+      "description": "Those three bytes under ECDSA; the bound value is the same digest as the BIP-340 vectors.",
+      "input": {
+        "encoding": "hex",
+        "data": "decade"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "ecdsa_secp256k1_sha256",
+      "payloadHex": "decade",
+      "payloadLength": 3,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+      "messageDigestHex": "3e1a914a91ed897e6e20423b3761a6026a9cdd039867f74e509d4f8af885f0e4",
+      "signatureDeterminism": "rfc6979",
+      "auxRandHex": null,
+      "signature": {
+        "scheme": "ecdsa_secp256k1_sha256",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "891dad2e657d3a1d4afb740154ab3e9297ec1155b54644034a57e8e2307dbfd613f0340af5dce87ea313f7a8a68e4e09baab7353286247695f126fb55e99e06c",
+        "verifyingKey": "028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7"
+      }
+    },
+    {
+      "name": "ecdsa-text-decade",
+      "description": "The six-character text payload under ECDSA.",
+      "input": {
+        "encoding": "text",
+        "data": "decade"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "ecdsa_secp256k1_sha256",
+      "payloadHex": "646563616465",
+      "payloadLength": 6,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a363a646563616465",
+      "messageDigestHex": "691d8be9cb28a83b8a95a46417cd51427a5a2fc1aa7b4a4420848b984794ebb5",
+      "signatureDeterminism": "rfc6979",
+      "auxRandHex": null,
+      "signature": {
+        "scheme": "ecdsa_secp256k1_sha256",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a363a646563616465",
+        "signature": "2049e8ecd848f76db013961408148507600814f9616afb2cc602efceda9e5b090906c894e8ccb1d99cbf7e339d56a0f75c450fefcb4d95709f301ef59ce44e72",
+        "verifyingKey": "028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7"
+      }
+    },
+    {
+      "name": "ecdsa-hex-decade-second-key",
+      "description": "The ECDSA message signed by the second key.",
+      "input": {
+        "encoding": "hex",
+        "data": "decade"
+      },
+      "valid": true,
+      "key": "key-b",
+      "scheme": "ecdsa_secp256k1_sha256",
+      "payloadHex": "decade",
+      "payloadLength": 3,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+      "messageDigestHex": "3e1a914a91ed897e6e20423b3761a6026a9cdd039867f74e509d4f8af885f0e4",
+      "signatureDeterminism": "rfc6979",
+      "auxRandHex": null,
+      "signature": {
+        "scheme": "ecdsa_secp256k1_sha256",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "a0691e91f2594cd63d5d9bc8d5fb9bdd63b011a22363705af2ea178dac579e2f1c4da35cf434dff0f4ff051de047882d0e3ba1b234c9379fa9b619ccb2606aac",
+        "verifyingKey": "02466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27"
+      }
+    },
+    {
+      "name": "schnorr-text-ascii",
+      "description": "A plain ASCII sign-in challenge, naming the party asking and carrying a nonce, over two lines.",
+      "input": {
+        "encoding": "text",
+        "data": "example.com asks you to sign in.\n\nNonce: 6f2b8d1c47a903e5b8d24f6017c3ae9b"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "6578616d706c652e636f6d2061736b7320796f7520746f207369676e20696e2e0a0a4e6f6e63653a203666326238643163343761393033653562386432346636303137633361653962",
+      "payloadLength": 73,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a37333a6578616d706c652e636f6d2061736b7320796f7520746f207369676e20696e2e0a0a4e6f6e63653a203666326238643163343761393033653562386432346636303137633361653962",
+      "messageDigestHex": "2efaad5cf8134cf1f0c94502e500cf5ecfeb33246a36b36c02d193ca0ee7b3c6",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "79c2da5905c19046096d0fc36c0339c792e98cc02d11533c17900db23f0cf8b8",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a37333a6578616d706c652e636f6d2061736b7320796f7520746f207369676e20696e2e0a0a4e6f6e63653a203666326238643163343761393033653562386432346636303137633361653962",
+        "signature": "955fce9b1a9f821fcd28351cb0c15a6090455dd63e2e8b967c8f14238095eaa248f6af195d7a770dddf6424a78a6d3ea65c27cbae2b58071c39f62f7da7ace5c",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-text-non-ascii",
+      "description": "Latin text with diacritics: 26 UTF-8 bytes over 17 characters.",
+      "input": {
+        "encoding": "text",
+        "data": "zażółć gęślą jaźń"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "7a61c5bcc3b3c582c4872067c499c59b6cc485206a61c5bac584",
+      "payloadLength": 26,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a32363a7a61c5bcc3b3c582c4872067c499c59b6cc485206a61c5bac584",
+      "messageDigestHex": "0258f12b1786e911aec91bd6001c587bdad2e1ea16445e83595ca2ed1ff7851f",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "40b9ad6b4ebffe36a0755556f5ccf8bb411e87088c95b737fdaac6f1addda5ec",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a32363a7a61c5bcc3b3c582c4872067c499c59b6cc485206a61c5bac584",
+        "signature": "6d3e1f3e3cb8c4c1a70592d3c4f9c639aa14d475662fec7dd1e961f6f479242acd535898f824ae30f379345bfa8e3ac498f51854c91238be52fbc12217e39248",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-text-astral",
+      "description": "A character outside the basic multilingual plane, encoded as one four-byte UTF-8 sequence.",
+      "input": {
+        "encoding": "text",
+        "data": "🌙 midnight"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "f09f8c99206d69646e69676874",
+      "payloadLength": 13,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a31333af09f8c99206d69646e69676874",
+      "messageDigestHex": "2e7cb6420bc7846b13117af8c44f9f361334367ee4c8ba8f1615834b2b31675b",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "25372aaf376757331925c79c32872307528d4d7c4a3246b4c478d9d811c42aa3",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a31333af09f8c99206d69646e69676874",
+        "signature": "6e1a3789df4b0c208e36d91a32e61e7ff3a82d7f9f15a764fb6ceaecdc3b46501f72a857c061e57b4c9a55a6e9bc928a4d7865f3ee874bb07757e153182dc694",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "ecdsa-text-astral",
+      "description": "The same astral-plane payload under ECDSA.",
+      "input": {
+        "encoding": "text",
+        "data": "🌙 midnight"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "ecdsa_secp256k1_sha256",
+      "payloadHex": "f09f8c99206d69646e69676874",
+      "payloadLength": 13,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a31333af09f8c99206d69646e69676874",
+      "messageDigestHex": "2e7cb6420bc7846b13117af8c44f9f361334367ee4c8ba8f1615834b2b31675b",
+      "signatureDeterminism": "rfc6979",
+      "auxRandHex": null,
+      "signature": {
+        "scheme": "ecdsa_secp256k1_sha256",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a31333af09f8c99206d69646e69676874",
+        "signature": "d0e00395fb21592bba76ac36afff9e7e04e4105acbee3f8f60a499bb6c3df06c5fb95e4938a7e8fc5ab36d966ed0f120fe18bb5ebc1de3755d5d465f804b8a0f",
+        "verifyingKey": "028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7"
+      }
+    },
+    {
+      "name": "schnorr-text-decomposed-accent",
+      "description": "A decomposed accent (e + U+0301). An implementation applying NFC would sign two bytes, not three.",
+      "input": {
+        "encoding": "text",
+        "data": "é"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "65cc81",
+      "payloadLength": 3,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a333a65cc81",
+      "messageDigestHex": "62eddb73489a8ffd5e8c78cc216f3102bce987813d13efd8339e32df54a570e0",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "dc7802865da1e3136917282d0e2be1e5e8f155d48047cf21e397aa2f2e98aa00",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333a65cc81",
+        "signature": "5820e55cbd46475ce49a7accc6a492bb6487c3aa64f46abb60fe0df64408cdb029197e3f746b859fd86faa7f31f7a3b1c4311a5b72eba867607d96e11afec96d",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-text-payload-resembling-a-message",
+      "description": "A payload that is itself a well-formed prefixed message; the structural parse must still be unique.",
+      "input": {
+        "encoding": "text",
+        "data": "midnight_signed_message:0:"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "6d69646e696768745f7369676e65645f6d6573736167653a303a",
+      "payloadLength": 26,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a32363a6d69646e696768745f7369676e65645f6d6573736167653a303a",
+      "messageDigestHex": "e43510717beb02ef5801bea929c488f499563767a1a55dbd5e7214d8eaf6e107",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "b63359dbe79d87fb79c40a48953bae3a9e5d922bc96f4950620e2b3df8bdd466",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a32363a6d69646e696768745f7369676e65645f6d6573736167653a303a",
+        "signature": "2b2041bf8baa73e13b3fc7c01f0f471d45200361efc5a28bbf1beeed789b3efd116af5a1d1c246c7142b63150a1f4aed847335b51f5a5dee7188ebce7b4eaa13",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-hex-single-zero-byte",
+      "description": "A one-byte payload that is NUL; the message is not NUL-terminated and is not shortened.",
+      "input": {
+        "encoding": "hex",
+        "data": "00"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "00",
+      "payloadLength": 1,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a313a00",
+      "messageDigestHex": "bf9b004198b483e5071d19529ed473b19ad6fe11a824aff83f8dd0e25f45e82e",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "9c4a3d991a7ff839054ab1d2d3ac4b81b86659fdea8fbce22eec9ee64ae0e223",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a313a00",
+        "signature": "65500b92aa677e34ee7b0946b7a09cab3e85db08c7093ac97250d70eb31d824c84edad2455febadf1934d0a5d27a4d96c601559fc3b1947349c9b6a04839b58c",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-hex-nine-bytes",
+      "description": "Nine bytes: a one-digit decimal length.",
+      "input": {
+        "encoding": "hex",
+        "data": "000102030405060708"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "000102030405060708",
+      "payloadLength": 9,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a393a000102030405060708",
+      "messageDigestHex": "1abdd8164902bcd5a19ed83391e64e7fd326cbf6388cada5ff00e2bfd7fae4b1",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "39f88ca8cbd1a05e841d6e53b7cec47c8ba807b54dbf4606b8360138cfcd545c",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a393a000102030405060708",
+        "signature": "d6a4c5319dd6c1b35e1a8b334a4383aaccf1a6199daac42a9bddf445992d64c79cc0b2aaef6b42e7d05c0895aeea9e3534017232126a82330e9bad8ff68ec993",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-hex-ten-bytes",
+      "description": "Ten bytes: the decimal length gains a digit, so the message gains a byte.",
+      "input": {
+        "encoding": "hex",
+        "data": "00010203040506070809"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "00010203040506070809",
+      "payloadLength": 10,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a31303a00010203040506070809",
+      "messageDigestHex": "54e6362d8d9ff66464ba9b8b3d4c1dd4cf77e1ba1487e1426d1dca9e61419643",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "ce68c72bf834fe79f42437c7cb2e4b5882f8bf1c016847fc246df580c1e1a9b9",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a31303a00010203040506070809",
+        "signature": "116aec832269a275d65a999464a27ac3b9b722fa74f05cb175a40f37edee70d8546dfeaaa6290fdcbe576671f0d7c60094e00aa5edbfae38421bbc83f39312cf",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-hex-ninety-nine-bytes",
+      "description": "Ninety-nine bytes: a two-digit decimal length.",
+      "input": {
+        "encoding": "hex",
+        "data": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162",
+      "payloadLength": 99,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a39393a000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162",
+      "messageDigestHex": "392237293408c71616d4ad6c925363973c1178ab87dd3fa81b62ec10da3394d6",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "8ac4318639a6b3d3a23e34eb3ba7c60cee7716858336b3116f3f9fa8abd97c16",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a39393a000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162",
+        "signature": "d7914ffb2f6701a7a35c7815db594fba58fd0060c550820a20c0935570e6c003819b4982639816b9ee66b4155604f38220cc68ea13852e2f856102f77a94206e",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-hex-one-hundred-bytes",
+      "description": "One hundred bytes: a three-digit decimal length.",
+      "input": {
+        "encoding": "hex",
+        "data": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f60616263"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f60616263",
+      "payloadLength": 100,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a3130303a000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f60616263",
+      "messageDigestHex": "e672c5f74b5b65d6fe6b211990462b73c2f00fa660a2bb333879f63eea9430f6",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "7b8c6caa50c7842062b2cbd3a89b2ddf209e49c9e8d16a8f7cf67b3d9dcdbee5",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a3130303a000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f60616263",
+        "signature": "b707d316da2631e04a60b4cc01efdb09cd2a2c767003eb082775f45c138ab63fbc27cdf4689e6e3a887d84154979dcae4f43b073933df382c6717376bedf4994",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "schnorr-hex-thirty-two-byte-challenge",
+      "description": "A 32-byte challenge whose message and verifying key match a wallet-produced vector the ledger accepted; the signature differs because the wallet’s auxiliary randomness was not recorded.",
+      "input": {
+        "encoding": "hex",
+        "data": "c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00",
+      "payloadLength": 32,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a33323ac0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00",
+      "messageDigestHex": "942601bbdd0d62fdd27942db22c09ecfd4ddbc7078ed8cbba00595c99a173dbd",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "f75c4ecb76416b56a8dfba62454025bb47b93bf06100057cd3b32844c995ab7b",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a33323ac0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00",
+        "signature": "1df03aaf3b832440b48a10833fba66eb99f8a2f34838a71a7b98403b78d8b3f70393cd3ec48a8deb8df0590713f31c656106f1d25676c6769717c2ac46230622",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "reference": "midnightntwrk/passport experiments/bip340-wallet-gate/evidence/p1-vector-connector.json @ ac19629210c9b6e76e214ebe9755a775be5dca50"
+    },
+    {
+      "name": "ecdsa-hex-thirty-two-byte-challenge",
+      "description": "The same 32-byte challenge under ECDSA.",
+      "input": {
+        "encoding": "hex",
+        "data": "c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "ecdsa_secp256k1_sha256",
+      "payloadHex": "c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00",
+      "payloadLength": 32,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a33323ac0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00",
+      "messageDigestHex": "942601bbdd0d62fdd27942db22c09ecfd4ddbc7078ed8cbba00595c99a173dbd",
+      "signatureDeterminism": "rfc6979",
+      "auxRandHex": null,
+      "signature": {
+        "scheme": "ecdsa_secp256k1_sha256",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a33323ac0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00c0ffee00",
+        "signature": "47213207567900e4eed07c8dee73668fa413d287ca1aef74cfb1964be6cd477d5d4d9042302ae78f1e8e2383964209ca43f8198eda27a0dcf2cae8dfabe29325",
+        "verifyingKey": "028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7"
+      }
+    },
+    {
+      "name": "schnorr-text-byte-order-mark",
+      "description": "A leading U+FEFF is ordinary content: it is encoded as ef bb bf, never stripped, and never added.",
+      "input": {
+        "encoding": "text",
+        "data": "﻿midnight"
+      },
+      "valid": true,
+      "key": "key-a",
+      "scheme": "schnorr_bip340",
+      "payloadHex": "efbbbf6d69646e69676874",
+      "payloadLength": 11,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a31313aefbbbf6d69646e69676874",
+      "messageDigestHex": "05d7e0b4bd2eb25a18bb30bfc058b51a43ebaa5b06bc0063ebf65b2d34e7db80",
+      "signatureDeterminism": "bip340-aux-fixed",
+      "auxRandHex": "0064d503297f56bcbb99527fc1acdfc8abb1330528947dca07ee7d4406fb93db",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a31313aefbbbf6d69646e69676874",
+        "signature": "1b0b999156b9d5b7045d0977b4efe00245b9e4cee1487e43b9542981afe92200f84af1cd49e6cd8312dd5d3b94b274c9ba442bf659152f09a4af8f3e530105e3",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      }
+    },
+    {
+      "name": "ecdsa-hex-decade-odd-y-key",
+      "description": "A third key whose compressed verifying key leads with 03; a verifier that assumes 02 fails only here.",
+      "input": {
+        "encoding": "hex",
+        "data": "decade"
+      },
+      "valid": true,
+      "key": "key-c",
+      "scheme": "ecdsa_secp256k1_sha256",
+      "payloadHex": "decade",
+      "payloadLength": 3,
+      "messageHex": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+      "messageDigestHex": "3e1a914a91ed897e6e20423b3761a6026a9cdd039867f74e509d4f8af885f0e4",
+      "signatureDeterminism": "rfc6979",
+      "auxRandHex": null,
+      "signature": {
+        "scheme": "ecdsa_secp256k1_sha256",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "0a6bb0af80820bc5f751c79c2544d11ff5ba2b51e6e0c2bb385963e75f4832815a479d60d3daa9c45bcbe5ac5a81c0b5566b0379adb50510a8aa63acbbfe1afe",
+        "verifyingKey": "03e11f40af6b41f494bfbc27c47a178ce572e8b8ca687cc67e1298514861ac5e48"
+      }
+    },
+    {
+      "name": "invalid-hex-odd-length",
+      "description": "Odd-length hex must be rejected, never truncated and never padded.",
+      "kind": "payload",
+      "input": {
+        "encoding": "hex",
+        "data": "abc"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-hex-zero-x-prefix",
+      "description": "A 0x prefix must be rejected, not stripped.",
+      "kind": "payload",
+      "input": {
+        "encoding": "hex",
+        "data": "0xdecade"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-hex-zero-x-prefix-uppercase",
+      "description": "The uppercase 0X prefix likewise.",
+      "kind": "payload",
+      "input": {
+        "encoding": "hex",
+        "data": "0Xdecade"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-hex-whitespace",
+      "description": "Whitespace inside hex must be rejected, not stripped.",
+      "kind": "payload",
+      "input": {
+        "encoding": "hex",
+        "data": "dec ade"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-hex-underscore",
+      "description": "A digit-group separator is not part of the hex alphabet.",
+      "kind": "payload",
+      "input": {
+        "encoding": "hex",
+        "data": "dec_ade"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-hex-out-of-alphabet",
+      "description": "A character outside [0-9a-fA-F] must be rejected.",
+      "kind": "payload",
+      "input": {
+        "encoding": "hex",
+        "data": "decadg"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-base64-length-one-mod-four",
+      "description": "A base64 length of 1 mod 4 must be rejected; a permissive decoder invents bytes here.",
+      "kind": "payload",
+      "input": {
+        "encoding": "base64",
+        "data": "A"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-base64-length-one-mod-four-longer",
+      "description": "The same defect past the first quantum.",
+      "kind": "payload",
+      "input": {
+        "encoding": "base64",
+        "data": "YWJjZ"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-base64-unpadded",
+      "description": "Padding is required: the length must be a multiple of 4.",
+      "kind": "payload",
+      "input": {
+        "encoding": "base64",
+        "data": "YQ"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-base64-url-safe-alphabet",
+      "description": "The URL-safe alphabet is a different encoding and must be rejected.",
+      "kind": "payload",
+      "input": {
+        "encoding": "base64",
+        "data": "___-"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-base64-line-break",
+      "description": "A line-wrapped payload must be rejected, not unwrapped.",
+      "kind": "payload",
+      "input": {
+        "encoding": "base64",
+        "data": "YWJj\nZGVm"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-base64-space",
+      "description": "A space inside base64 must be rejected, not stripped.",
+      "kind": "payload",
+      "input": {
+        "encoding": "base64",
+        "data": "YWJj ZGVm"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-base64-out-of-alphabet",
+      "description": "A character outside the RFC 4648 section 4 alphabet must be rejected.",
+      "kind": "payload",
+      "input": {
+        "encoding": "base64",
+        "data": "YWJ$"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-base64-padding-inside",
+      "description": "Padding may only end the final quantum.",
+      "kind": "payload",
+      "input": {
+        "encoding": "base64",
+        "data": "YW=j"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-base64-padding-first",
+      "description": "Padding that is not final at all; a decoder that scans for = anywhere invents bytes here.",
+      "kind": "payload",
+      "input": {
+        "encoding": "base64",
+        "data": "=AAA"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-base64-padding-only",
+      "description": "Four padding characters: more padding than a final quantum can carry, and no data at all.",
+      "kind": "payload",
+      "input": {
+        "encoding": "base64",
+        "data": "===="
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-base64-trailing-bits-two-character-quantum",
+      "description": "A two-character final quantum whose four spare bits are set; YQ== is the canonical spelling of the same byte.",
+      "kind": "payload",
+      "input": {
+        "encoding": "base64",
+        "data": "Yf=="
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-base64-trailing-bits-three-character-quantum",
+      "description": "A three-character final quantum whose two spare bits are set; YWI= is the canonical spelling of the same two bytes.",
+      "kind": "payload",
+      "input": {
+        "encoding": "base64",
+        "data": "YWL="
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-text-unpaired-high-surrogate",
+      "description": "An unpaired high surrogate must be rejected, not replaced with U+FFFD.",
+      "kind": "payload",
+      "input": {
+        "encoding": "text",
+        "data": "\ud83d"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-text-unpaired-low-surrogate",
+      "description": "An unpaired low surrogate likewise.",
+      "kind": "payload",
+      "input": {
+        "encoding": "text",
+        "data": "\ude00"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-encoding-unrecognised",
+      "description": "An encoding that names none of the three must be rejected, not mapped onto the nearest one: utf8 is not text, however obvious the intent looks.",
+      "kind": "payload",
+      "input": {
+        "encoding": "utf8",
+        "data": "deca"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-encoding-absent",
+      "description": "No encoding at all. There is no default: a producer that sniffs the data here has three readings to choose between and no ground to choose on.",
+      "kind": "payload",
+      "input": {
+        "data": "deca"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "invalid-keytype-shielded",
+      "description": "A shielded keyType must be rejected even though the payload decodes; only unshielded keys sign messages.",
+      "kind": "payload",
+      "input": {
+        "encoding": "text",
+        "data": "hello",
+        "keyType": "shielded"
+      },
+      "valid": false,
+      "error": {
+        "code": "InvalidRequest"
+      }
+    },
+    {
+      "name": "reject-signature-is-not-an-object",
+      "description": "The Signature is JSON null, so there is no field to read; a verifier reaches a verdict instead of failing on the missing object.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": null,
+      "expectedFailureStep": 1
+    },
+    {
+      "name": "reject-signature-is-a-json-array",
+      "description": "A genuine Signature wrapped in a single-element JSON array, the other value typeof calls an object, and the shape a producer that batches its results returns. The container step is what refuses it: a verifier that unwraps the array accepts a Signature that never arrived as one.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": [
+        {
+          "scheme": "schnorr_bip340",
+          "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+          "signature": "8383c995d56ccb63a5d5ce7c2d44dd42ebe928724350a820c9aeeca1678168d1b87b17f432e51ee4875aa1051aa98d8272b3925b664998b59a95e9e0f4fa7417",
+          "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+        }
+      ],
+      "expectedFailureStep": 1
+    },
+    {
+      "name": "reject-scheme-absent",
+      "description": "A genuine Schnorr signature whose Signature omits scheme altogether, as a producer written before the field existed emits it. The field is required: there is no scheme to fall back to, and a verifier that supplies one accepts a signature it must refuse.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "8383c995d56ccb63a5d5ce7c2d44dd42ebe928724350a820c9aeeca1678168d1b87b17f432e51ee4875aa1051aa98d8272b3925b664998b59a95e9e0f4fa7417",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 1
+    },
+    {
+      "name": "reject-scheme-is-null",
+      "description": "A null scheme names no scheme; only the two literals do, and a verifier must not read null as a request to pick one.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": null,
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "8383c995d56ccb63a5d5ce7c2d44dd42ebe928724350a820c9aeeca1678168d1b87b17f432e51ee4875aa1051aa98d8272b3925b664998b59a95e9e0f4fa7417",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 1
+    },
+    {
+      "name": "reject-scheme-is-the-ledger-tag",
+      "description": "The tag the Midnight ledger uses for the same scheme, forwarded verbatim into scheme. It is neither of the two literals the discriminator admits, so a verifier rejects it rather than mapping it.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "8383c995d56ccb63a5d5ce7c2d44dd42ebe928724350a820c9aeeca1678168d1b87b17f432e51ee4875aa1051aa98d8272b3925b664998b59a95e9e0f4fa7417",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 1
+    },
+    {
+      "name": "reject-uppercase-wire-hex",
+      "description": "Everything is genuine except that data is uppercase; the wire form is lowercase and is not case-insensitive.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6D69646E696768745F7369676E65645F6D6573736167653A333ADECADE",
+        "signature": "8383c995d56ccb63a5d5ce7c2d44dd42ebe928724350a820c9aeeca1678168d1b87b17f432e51ee4875aa1051aa98d8272b3925b664998b59a95e9e0f4fa7417",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 2
+    },
+    {
+      "name": "reject-uppercase-signature",
+      "description": "Everything is genuine except that signature is uppercase; the same 64 bytes either way, so nothing but the wire form refuses it. Without this the casing rule is pinned on two of the three fields and a verifier may lowercase the third.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "8383C995D56CCB63A5D5CE7C2D44DD42EBE928724350A820C9AEECA1678168D1B87B17F432E51EE4875AA1051AA98D8272B3925B664998B59A95E9E0F4FA7417",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 2
+    },
+    {
+      "name": "reject-uppercase-verifying-key",
+      "description": "Everything is genuine except that verifyingKey is uppercase; hex decodes to the same point either way, so nothing but the wire form refuses it.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "8383c995d56ccb63a5d5ce7c2d44dd42ebe928724350a820c9aeeca1678168d1b87b17f432e51ee4875aa1051aa98d8272b3925b664998b59a95e9e0f4fa7417",
+        "verifyingKey": "989C0B76CB563971FDC9BEF31EC06C3560F3249D6EE9E5D83C57625596E05F6F"
+      },
+      "expectedFailureStep": 2
+    },
+    {
+      "name": "reject-odd-length-data",
+      "description": "A genuine data field with one hex character appended: a decoder that drops the trailing half byte rebuilds the message and accepts, so nothing but the even-length rule refuses it.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade0",
+        "signature": "8383c995d56ccb63a5d5ce7c2d44dd42ebe928724350a820c9aeeca1678168d1b87b17f432e51ee4875aa1051aa98d8272b3925b664998b59a95e9e0f4fa7417",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 2
+    },
+    {
+      "name": "reject-odd-length-signature",
+      "description": "A genuine signature field with one hex character appended: Buffer.from drops the trailing half byte, so a verifier that counts bytes after decoding sees the 64 it wants and accepts. The even-length rule is what refuses it, and it has to be pinned on signature separately because the 64-byte rule alone would let an odd count through a decode-first verifier.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "8383c995d56ccb63a5d5ce7c2d44dd42ebe928724350a820c9aeeca1678168d1b87b17f432e51ee4875aa1051aa98d8272b3925b664998b59a95e9e0f4fa74170",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 2
+    },
+    {
+      "name": "reject-uncompressed-sec1-verifying-key",
+      "description": "A real but uncompressed 65-byte SEC1 point under ECDSA; only the 33-byte compressed form is admitted.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "ecdsa_secp256k1_sha256",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "891dad2e657d3a1d4afb740154ab3e9297ec1155b54644034a57e8e2307dbfd613f0340af5dce87ea313f7a8a68e4e09baab7353286247695f126fb55e99e06c",
+        "verifyingKey": "048d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f725fb9f0eb662b8319979cb64973d678eb98baff7f60df817f47f64fc91d40f60"
+      },
+      "expectedFailureStep": 2
+    },
+    {
+      "name": "reject-odd-length-verifying-key",
+      "description": "A genuine verifyingKey with one hex character appended, the third and last field the even-length rule governs. As with signature, a verifier that decodes first and counts bytes afterwards drops the trailing half byte, recovers the real key and accepts.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "8383c995d56ccb63a5d5ce7c2d44dd42ebe928724350a820c9aeeca1678168d1b87b17f432e51ee4875aa1051aa98d8272b3925b664998b59a95e9e0f4fa7417",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f0"
+      },
+      "expectedFailureStep": 2
+    },
+    {
+      "name": "reject-der-encoded-signature",
+      "description": "A genuine ECDSA signature re-spelled as DER, which is what OpenSSL and libsecp256k1 emit by default: the same (r, s) over the same digest, so a verifier that hands whatever length it was given to a DER-accepting library verifies it and accepts. Only the 64-byte rule refuses it.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "ecdsa_secp256k1_sha256",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "3045022100891dad2e657d3a1d4afb740154ab3e9297ec1155b54644034a57e8e2307dbfd6022013f0340af5dce87ea313f7a8a68e4e09baab7353286247695f126fb55e99e06c",
+        "verifyingKey": "028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7"
+      },
+      "expectedFailureStep": 2
+    },
+    {
+      "name": "reject-x-only-key-under-ecdsa",
+      "description": "The 32-byte x coordinate of a genuine ECDSA verifying key, with the SEC1 lead byte dropped: a verifier that re-adds one — the BIP-340 key shape reaching an ECDSA signature — reconstructs the real point and accepts. Only the length rule refuses it, and the uncompressed vector cannot stand in for it because that one is caught by the lead byte instead.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "ecdsa_secp256k1_sha256",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "891dad2e657d3a1d4afb740154ab3e9297ec1155b54644034a57e8e2307dbfd613f0340af5dce87ea313f7a8a68e4e09baab7353286247695f126fb55e99e06c",
+        "verifyingKey": "8d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7"
+      },
+      "expectedFailureStep": 2
+    },
+    {
+      "name": "reject-stringified-signature-object",
+      "description": "A tagged ledger value coerced with String(...) rather than unwrapped: well-formed enough to look like a field, never a signature.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "[object Object]",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 2
+    },
+    {
+      "name": "reject-data-absent",
+      "description": "The signed bytes are missing altogether, so there is nothing to parse or to compare against the payload.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "signature": "8383c995d56ccb63a5d5ce7c2d44dd42ebe928724350a820c9aeeca1678168d1b87b17f432e51ee4875aa1051aa98d8272b3925b664998b59a95e9e0f4fa7417",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 2
+    },
+    {
+      "name": "reject-data-echoes-the-payload",
+      "description": "data carries the payload alone with no prefix: the echo several producers ship, and a signature over a message no one can reconstruct.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "decade",
+        "signature": "8383c995d56ccb63a5d5ce7c2d44dd42ebe928724350a820c9aeeca1678168d1b87b17f432e51ee4875aa1051aa98d8272b3925b664998b59a95e9e0f4fa7417",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 4
+    },
+    {
+      "name": "reject-foreign-prefix",
+      "description": "A genuine signature over a message built on a different 24-byte separator: the length header, the payload and the signature are all sound, so the prefix is the only thing that refuses it. Without this vector a verifier that never compares the prefix passes the whole file, and the prefix is what keeps a message signature from being read as any other signed structure.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7472616e73616374696f6e5f736967333adecade",
+        "signature": "c550d76a1b9427d00001dca39ad342ee694ba7a53322c8eb889555a85b730648a2235aa05277779780d6b51f1f2829cb47d35ed913f0a79ed835bf523043c117",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 4
+    },
+    {
+      "name": "reject-leading-zero-length",
+      "description": "A genuinely signed message whose decimal length is zero-padded; the length has exactly one spelling.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a30333adecade",
+        "signature": "bc053a23ab7c89d9988e77b8a119945480fd0da9294263243605f9bbcfc768f94c6d49ee1ad31758097c8db1888c683fed17917fece8aeceeb0d56b44b8db76f",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 5
+    },
+    {
+      "name": "reject-unterminated-length",
+      "description": "A genuinely signed message whose digit run is not followed by a colon, so the payload never begins.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a33decade",
+        "signature": "ac773c00f06f02fc0aaec92dcf1d41abf271f15dc3f37541e1e9722d78433a710b9ad103470e0b549904e9af2e71ee220c547a136ddc655f6af9fb12bfaff8f2",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 5
+    },
+    {
+      "name": "reject-declared-length-mismatch",
+      "description": "A genuinely signed message declaring four bytes and carrying three; a truncating producer emits exactly this.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a343adecade",
+        "signature": "fc8c118eb3b84ed6a2c98f0d48325c43c7ca1416aa6e723ba3c0dd0a8421c9df57bb39868ffece8f8dd9e50889902429b95d6f8bdbc2d80ac5d6771d198b3488",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 6
+    },
+    {
+      "name": "reject-payload-is-not-the-requested-payload",
+      "description": "A structurally perfect, genuinely signed message over one byte the caller did not send.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecadd",
+        "signature": "7a23b7e83d5c367c4187c360d26ddd1a329bb49feab8b2340e081934b06df2037872063726e1eb08ea7c159b012f9f77a19af5c1570e650f07e0524c889f0dd0",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 7
+    },
+    {
+      "name": "reject-high-s-ecdsa-twin",
+      "description": "The (r, n-s) twin of a genuine ECDSA signature: valid curve arithmetic, forged from the signature alone, and non-canonical.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "ecdsa_secp256k1_sha256",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "891dad2e657d3a1d4afb740154ab3e9297ec1155b54644034a57e8e2307dbfd6ec0fcbf50a2317815cec08575971b1f50003699386e658d260bfeed7719c60d5",
+        "verifyingKey": "028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7"
+      },
+      "expectedFailureStep": 9
+    },
+    {
+      "name": "reject-signature-over-a-different-message",
+      "description": "Every structural check passes and the payload matches, but the signature was made over other bytes.",
+      "kind": "verification",
+      "valid": false,
+      "payloadHex": "decade",
+      "signature": {
+        "scheme": "schnorr_bip340",
+        "data": "6d69646e696768745f7369676e65645f6d6573736167653a333adecade",
+        "signature": "7a23b7e83d5c367c4187c360d26ddd1a329bb49feab8b2340e081934b06df2037872063726e1eb08ea7c159b012f9f77a19af5c1570e650f07e0524c889f0dd0",
+        "verifyingKey": "989c0b76cb563971fdc9bef31ec06c3560f3249d6ee9e5d83c57625596e05f6f"
+      },
+      "expectedFailureStep": 9
+    }
+  ]
+}


### PR DESCRIPTION
Per abstract - message signing is part of the DApp Connector API spec, but that document is not easy to find, nor the exact paragraph easy to find. It also leaves some aspects of the signing API open to interpretation.

This MIP is proposed to address those issues.